### PR TITLE
add readline support

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -28,6 +28,10 @@ shards:
     git: https://github.com/l3kn/pcf-parser.git
     version: 0.1.1
 
+  reply:
+    git: https://github.com/i3oris/reply.git
+    version: 0.4.0
+
   sixteen:
     git: https://github.com/ralsina/sixteen.git
     version: 0.5.2

--- a/shard.yml
+++ b/shard.yml
@@ -15,6 +15,8 @@ development_dependencies:
 dependencies:
   markterm:
     github: ralsina/markterm
+  reply:
+    github: I3oris/reply
 
 targets:
   enkaidu:

--- a/src/main.cr
+++ b/src/main.cr
@@ -1,5 +1,6 @@
 require "./enkaidu/session"
 require "./enkaidu/console_renderer"
+require "./query_reader"
 
 module Enkaidu
   class Main
@@ -69,8 +70,8 @@ module Enkaidu
       puts Markd.to_term(WELCOME)
       recorder << "["
       while !done?
-        print "----\nQUERY > ".colorize(:yellow)
-        if q = gets
+        puts "----".colorize(:yellow)
+        if q = reader.read_next
           case q = q.strip
           when .starts_with?("/") then commands(q)
           else
@@ -84,6 +85,10 @@ module Enkaidu
       recorder << "]"
     ensure
       recorder.close
+    end
+
+    private def reader
+      @reader ||= QueryReader.new
     end
   end
 end

--- a/src/query_reader.cr
+++ b/src/query_reader.cr
@@ -1,0 +1,34 @@
+require "reply"
+
+class QueryReader < Reply::Reader
+  def prompt(io : IO, line_number : Int32, color : Bool) : Nil
+    p = "QUERY > "
+    p = p.colorize(:yellow) if color
+
+    io << p
+  end
+
+  # def highlight(expression : String) : String
+  #   # Highlight the expression
+  # end
+
+  # def continue?(expression : String) : Bool
+  #   # Return whether the interface should continue on multiline, depending of the expression
+  # end
+
+  # def format(expression : String) : String?
+  #   # Reformat when expression is submitted
+  # end
+
+  # def indentation_level(expression_before_cursor : String) : Int32?
+  #   # Compute the indentation from the expression
+  # end
+
+  def save_in_history?(expression : String) : Bool
+    true
+  end
+
+  # def auto_complete(name_filter : String, expression : String) : {String, Array(String)}
+  #   # Return the auto-completion result from expression
+  # end
+end


### PR DESCRIPTION
Add Readline-like support for command history and command editing.

It's "Readline-like" because it's pure Crystal - no GNU Readline bindings, so we don't have to deal with supporting systems that don't have Readline available.