### PR TITLE
remove EOF warning

### DIFF
--- a/src/main.cr
+++ b/src/main.cr
@@ -77,7 +77,6 @@ module Enkaidu
             query(q)
           end
         else
-          renderer.warning("ERROR: Unexpected end of input IO")
           @done = true
         end
       end


### PR DESCRIPTION
- remove warning on EOF reading STDIN

Some people use CTRL+D to exit shells and other interactive programs. This is seen by the interactive program as end-of-file. Also, if we pipe input into a program, it will eventually read EOF, which is what we expect. I think we should consider EOF a normal case and just exit instead of warning the user about it.

<img width="773" height="235" alt="image" src="https://github.com/user-attachments/assets/6298c250-3667-401d-8642-c29f588e05f0" />

<img width="877" height="299" alt="image" src="https://github.com/user-attachments/assets/825dde33-93f2-4731-bb93-fe4aa13478c7" />

This MR removes the red text warning on EOF.

What do you think?


