### PR TITLE
add ops install action

### DIFF
--- a/ops.yml
+++ b/ops.yml
@@ -16,12 +16,13 @@ actions:
     description: Build for development (debugging)
     aliases: [build, bd]
   install:
+    quiet: true
     command: |
       BRANCH=$(git branch --show-current)
       [ "$BRANCH" == "main" ] || echo 1>&2 "ops: WARNING: not on 'main' branch."
 
       if [ -e "$INSTALL_DIR" ]; then
-        ops build-release && cp bin/release/enkaidu "$INSTALL_DIR/"
+        ops build-release && cp bin/release/$APP "$INSTALL_DIR/"
       else
         echo 1>&2 "ops: The directory '$INSTALL_DIR' does not exist."
       fi


### PR DESCRIPTION
I keep breaking my running Enkaidu while working on it. So I made this to build a release binary and copy it to my user's bin directory.

Now I can use a stable Enkaidu from main while working on new features.

The only thing I'd like to be able to change is that `ops` prints the whole multi-line shell command to the terminal when it's run. Maybe I'll add support for `quiet: true` to actions in `ops.yml`.