### PR TITLE
Shell command

### DIFF
--- a/src/enkaidu/console_renderer.cr
+++ b/src/enkaidu/console_renderer.cr
@@ -27,6 +27,16 @@ module Enkaidu
       puts "----".colorize(:green)
     end
 
+    def user_confirm_shell_command?(command)
+      puts "  CONFIRM: The assistant wants to run the following command:\n\n"
+      puts "  > #{command}\n\n".colorize(:red).bold
+      print "  Allow? [y/N] "
+      response = STDIN.raw &.read_char
+      puts response
+
+      ['y', 'Y'].includes?(response)
+    end
+
     def llm_tool_call(name, args)
       print "  CALL".colorize(:green)
       puts " #{name.colorize(:red)} " \

--- a/src/enkaidu/options.cr
+++ b/src/enkaidu/options.cr
@@ -6,6 +6,7 @@ module Enkaidu
     getter model_name : String? = nil
     getter? debug = false
     getter? stream = false
+    getter? enable_shell_command = true
     getter recorder_file : IO? = nil
     getter renderer : SessionRenderer
 
@@ -14,14 +15,15 @@ module Enkaidu
         parser.banner = "Usage: #{PROGRAM_NAME} [arguments]\n\nOptions"
         parser.on("-p NAME", "--provider=NAME", "The name of the provider: azure_openai, openai, or ollama") { |name| @provider_name = name }
         parser.on("-m NAME", "--model=NAME", "Some providers require a model.") { |name| @model_name = name }
+        parser.on("-S", "--streaming", "Enable streaming mode") { @stream = true }
         parser.on("-R FILEPATH", "--recorder-file=FILEPATH", "Record chat processing events to a JSON file") do |path|
           @recorder_file = File.open(path, "w")
         rescue ex
           error_and_exit_with "FATAL: Unable to create recorder file (\"#{path}\"): #{ex.message}", parser
         end
         parser.on("-D", "--debug", "Enable debug mode by sending raw responses to the recorder if configure (via -R)") { @debug = true }
-        parser.on("-S", "--streaming", "Enable streaming mode") { @stream = true }
-        parser.on("-h", "--help", "Show this help") do
+        parser.on("--disable-shell-command", "Disable the shell command tool") { @enable_shell_command = false }
+        parser.on("--help", "Show this help") do
           puts parser
           exit
         end

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -52,7 +52,7 @@ module Enkaidu
         with_tool ReplaceTextInTextFileTool.new
         with_tool RenameFileTool.new
         with_tool CreateDirectoryTool.new
-        with_tool ShellCommandTool.new
+        with_tool ShellCommandTool.new(renderer) if opts.enable_shell_command?
       end
 
       @renderer.streaming = chat.streaming?

--- a/src/enkaidu/session_renderer.cr
+++ b/src/enkaidu/session_renderer.cr
@@ -1,29 +1,33 @@
 # Defines callbacks from the app session
 # so that we can implement different rendering systems
-abstract class SessionRenderer
-  abstract def warning(message)
+module Enkaidu
+  abstract class SessionRenderer
+    abstract def warning(message)
 
-  abstract def error_with(message, help = nil)
+    abstract def error_with(message, help = nil)
 
-  abstract def user_query(query)
+    abstract def user_query(query)
 
-  abstract def user_calling_tools
+    abstract def user_calling_tools
 
-  abstract def llm_tool_call(name, args)
+    abstract def user_confirm_shell_command?(command)
 
-  abstract def llm_text(text)
+    abstract def llm_tool_call(name, args)
 
-  abstract def llm_error(err)
+    abstract def llm_text(text)
 
-  abstract def mcp_initialized(uri)
+    abstract def llm_error(err)
 
-  abstract def mcp_tools_found(count)
+    abstract def mcp_initialized(uri)
 
-  abstract def mcp_tool_ready(function)
+    abstract def mcp_tools_found(count)
 
-  abstract def mcp_calling_tool(uri, name, args)
+    abstract def mcp_tool_ready(function)
 
-  abstract def mcp_calling_tool_result(uri, name, result)
+    abstract def mcp_calling_tool(uri, name, args)
 
-  abstract def mcp_error(ex)
+    abstract def mcp_calling_tool_result(uri, name, result)
+
+    abstract def mcp_error(ex)
+  end
 end


### PR DESCRIPTION
## What

Add ShellCommandTool. It will only allow whitelisted executables, and it will disallow any commands with certain special shell character sequences, even if they run a whitelisted executable. All commands require user confirmation.

If this is too cautious, I could also have shell commands auto-approved if these two checks pass, but require user confirmation of other commands.

## Why

Right now, there's a lot of overlap with existing tools. However, `find` provides something new and might prove useful for LLMs.

Eventually, I'd like this to get to the point where Enkaidu call allow an LLM to automatically run unit tests in a project to test its own changes, run Enkaidu itself and check the output, lint its own changes, etc.

Also, I'd like to give the user the option to approve commands for certain executables for the current session, instead of approving every time, and maybe not require confirmation for safe commands using certain executables, for example `ls `.

## How

```
  ALLOWED_EXECUTABLES = ["ls", "cat", "grep", "whoami", "file", "wc", "find"]
  UNSAFE_STRINGS      = ["..", "|", "<", ">", ";", "&"]
```

- Only allowed executables can be called
- Any command containing unsafe strings is automatically disallowed
- The user must confirm every call, even for commands that pass the above checks
