### PR TITLE
Fix bug where model in config doesn't get used by Az OpenAI chat connection

### DIFF
--- a/src/llm/azure_openai/chat_connection.cr
+++ b/src/llm/azure_openai/chat_connection.cr
@@ -14,7 +14,7 @@ module LLM::AzureOpenAI
     end
 
     def model
-      ENV["AZURE_OPENAI_MODEL"]
+      super || ENV["AZURE_OPENAI_MODEL"]?
     end
 
     protected def url : String

--- a/src/llm/chat_connection.cr
+++ b/src/llm/chat_connection.cr
@@ -5,6 +5,8 @@ require "./chat"
 
 module LLM
   abstract class ChatConnection
+    protected property model : String? = nil
+
     def initialize
       @client = HTTP::Client.new(URI.parse(url))
     end

--- a/src/llm/ollama/chat_connection.cr
+++ b/src/llm/ollama/chat_connection.cr
@@ -9,6 +9,10 @@ module LLM::Ollama
       ENV.fetch("OLLAMA_ENDPOINT", "http://localhost:11434")
     end
 
+    def model
+      super || ENV["OLLAMA_MODEL"]?
+    end
+
     protected def path : String
       "/v1/chat/completions"
     end

--- a/src/llm/openai/chat.cr
+++ b/src/llm/openai/chat.cr
@@ -17,6 +17,12 @@ module LLM::OpenAI
     def initialize(@conn)
       super()
       @messages = [] of Message
+      @model = @conn.model
+    end
+
+    def with_model(model : String)
+      super
+      @conn.model = model
     end
 
     private def call_tool(tool : LLM::Function, tool_call : JSON::Any)

--- a/src/llm/openai/chat_connection.cr
+++ b/src/llm/openai/chat_connection.cr
@@ -18,7 +18,7 @@ module LLM::OpenAI
     end
 
     def model
-      ENV["OPENAI_MODEL"]
+      super || ENV["OPENAI_MODEL"]?
     end
 
     protected def path : String


### PR DESCRIPTION
The Azure Open AI protocol requires the model name to be part of the URL path. The path was being build by the Azure ChatConnection which didn't have a way to know the model in the Chat session, and the session needed it for the request payload. 

Fixed by adding a `property method` to base Chat Connection that the core Open AI Chat class uses to set the value when the app sets the model via `#with_model`.

> NOTE: I originally separated `ChatConnection` from `Chat` thinking the single OpenAI-specific `Chat` would be paired with the provider-specific `ChatConnection` derivative. After using this for a while I think maybe they don't need to be separate. Not urgent to fix but may be worth doing.