### PR TITLE
Add MCP transport type when setting up connection

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -16,6 +16,7 @@
 - [ ] Detect when MCP connection needs to be reset; there are some rules for this.
 - [ ] Find a canonical server to run locally to test the protocol better
 - [ ] Figure out how to improve MCP transport responsiveness. The MCP Inspector seems be deal with HTTP streaming much more responsively. My implementation, which needs `io.skip_to_end` after handling every response, seems sluggish.
+- [x] Support optional transport type when using MCP servers, to choose between `auto`, `legacy`, and `http`.
 - [x] Support the deprecated SSE transport 'cuz there are so many servers out there.
 - [x] Support MCP server authentication using bearer token
 

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -139,8 +139,9 @@ module Enkaidu
       end
     end
 
-    def use_mcp_server(url : String, auth_token : MCPC::AuthToken? = nil)
-      mcpc = MCPC::HttpConnection.new(url, tracing: opts.trace_mcp?, auth_token: auth_token)
+    def use_mcp_server(url : String, auth_token : MCPC::AuthToken? = nil, transport_type = MCPC::TransportType::AutoDetect)
+      mcpc = MCPC::HttpConnection.new(url, tracing: opts.trace_mcp?,
+        auth_token: auth_token, transport_type: transport_type)
       # puts "  INIT MCP connection: #{mcpc.uri}".colorize(:green)
       renderer.mcp_initialized(mcpc.uri)
       mcp_connections << mcpc

--- a/src/mcpc/transport_type.cr
+++ b/src/mcpc/transport_type.cr
@@ -1,0 +1,27 @@
+module MCPC
+  class TransportTypeException < Exception; end
+
+  enum TransportType
+    AutoDetect
+    LegacySSE
+    ModernHTTP
+
+    def label
+      case self
+      in .auto_detect? then "auto"
+      in .legacy_sse?  then "legacy"
+      in .modern_http? then "http"
+      end
+    end
+
+    def self.from(label) : TransportType
+      case label
+      when "auto"   then AutoDetect
+      when "legacy" then LegacySSE
+      when "http"   then ModernHTTP
+      else
+        raise TransportTypeException.new("Unknown parameter type label: #{label}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some MCP servers don't support fallback detection which can lead to long delays when attempting to auto-detect the MCP transport type. 

- Added transport type enum with following labels: auto, legacy, http
- Added optional `transport=` named param for `/use_mcp` command
- Transport type is passed when setting up MCP connection, default is `auto`
- Specifying the type is especially beneficial for modern `http` servers. 

### Examples

```
/use_mcp https://mcp.llmtxt.dev/sse transport=legacy
```
or
```
/use_mcp https://echo.mcp.inevitable.fyi/mcp transport=http
```

The latter is now faster to connect since it doesn't first try to make a legacy connection.
