### PR TITLE
Add MCP servers to config, with auto-load

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -6,6 +6,8 @@
 - [ ] Document the code classes (viz. fix `ops lint` warnings)
 - [ ] Setup GH action to build Linux and macOS binaries
 - [ ] Figure out `curl` and `bash` installation script
+- [x] Support configuring MCP servers in config YAML file
+- [x] Support session auto-loading of specific MCP servers
 - [x] Add a tool to save an image where the provided image is in the `data:` base-64-encoded form
 - [x] Does OpenAI protocol support input/output schema? The `parameters` value is a JSON schema (i.e. input), but non
 

--- a/src/enkaidu/config.cr
+++ b/src/enkaidu/config.cr
@@ -18,25 +18,41 @@ module Enkaidu
       getter env = {} of String => String
     end
 
-    class Options < ConfigSerializable
-      getter provider_type : String?
-      getter model : String?
-      getter recording_file : String?
-      getter input_history_file : String?
+    class MCP < ConfigSerializable
+      getter url : String
+      getter transport : String = "auto"
+      getter bearer_auth_token : String?
+    end
+
+    class Global < ConfigSerializable
       getter? trace_mcp = false
       getter? streaming = false
       getter? enable_shell_command = true
     end
 
-    getter session : Options?
+    class AutoLoad < ConfigSerializable
+      getter mcp_servers : Array(String) = [] of String
+    end
+
+    class Session < ConfigSerializable
+      getter provider_type : String?
+      getter model : String?
+      getter recording_file : String?
+      getter input_history_file : String?
+      getter auto_load : AutoLoad?
+    end
+
+    getter global : Global?
+    getter session : Session?
     getter llms = {} of String => LLM
+    getter mcp_servers = {} of String => MCP
 
     # ---------------------- end of content definition
 
     # Look for a model by its unique name and, if one exists, return its
     # model's enclosing LLM
     def find_llm_and_model_by?(unique_model_name)
-      llms.each do |name, llm|
+      llms.each do |_, llm|
         llm.models.try &.each do |model|
           if model.name == unique_model_name
             return {llm: llm, model: model}

--- a/src/main.cr
+++ b/src/main.cr
@@ -29,8 +29,8 @@ module Enkaidu
 
     WELCOME_MSG = "Welcome to Enkaidu"
     WELCOME     = <<-TEXT
-    This is your second-in-command(-line) designed to assist you with 
-    writing & maintaining code and other text-based content, by enabling LLMs 
+    This is your second-in-command(-line) designed to assist you with
+    writing & maintaining code and other text-based content, by enabling LLMs
     and connecting with MCP servers.
 
     When entering a query,
@@ -144,6 +144,8 @@ module Enkaidu
 
     def run
       renderer.info_with WELCOME_MSG, WELCOME, markdown: true
+      session.auto_load
+
       recorder << "["
       while !done?
         if q = reader.read_next

--- a/src/mcpc/transport_type.cr
+++ b/src/mcpc/transport_type.cr
@@ -14,14 +14,18 @@ module MCPC
       end
     end
 
-    def self.from(label) : TransportType
+    def self.from?(label) : TransportType?
       case label
       when "auto"   then AutoDetect
       when "legacy" then LegacySSE
       when "http"   then ModernHTTP
       else
-        raise TransportTypeException.new("Unknown parameter type label: #{label}")
+        nil
       end
+    end
+
+    def self.from(label) : TransportType
+      self.from?(label) || raise TransportTypeException.new("Unknown parameter type label: #{label}")
     end
   end
 end


### PR DESCRIPTION
This PR adds MCP servers to the config file, and allows a session to specify which ones to autoload at start. The following changes were made:

1. Used this opportunity to split `Config::Options` into two classes: `Config::Global` and `Config::Session`.
2. At the top level, `global:` and `session:` are mapped respectively
3. Added `Config::MCP` that helps configure a single server
4. At the top level added `mcp_servers:` as a named map of servers, where each is a unique name
5. Added `Config::AutoLoad` that for now has the `mcp_servers:` property which is an array of names of MCP servers to autoload
6. Added `auto_load:` property mapped to `Config::AutoLoad` to the `Config::Session` object

Here's an example of a config file that reflects all these changes:

```yaml
global:
  streaming: true
session:
  model: qwen3_8b_8K
  input_history_file: config/$environment/.enkaidu_history
  auto_load:
    mcp_servers: 
      - "echo"
llms:
  ollama:
    provider: ollama
    models:
      - name: qwen3_i4b_16K
        model: qwen3_instruct4b_16K
      - name: qwen3_8b_8K
        model: qwen3_8b_8K
mcp_servers:
  echo:  
    url: https://echo.mcp.inevitable.fyi/mcp
    transport: http
  semgrep:
    url: https://mcp.semgrep.ai/sse
    transport: sse
```

Using this config, when `enkaidu` starts it will auto load the `echo` MCP server after the welcome message.

```text
INFO: Reading config file: enkaidu.yaml
WARNING: Markdown formatted rendering is not supported when streaming is enabled (for now). Sorry.

Welcome to Enkaidu

  This is your second-in-command(-line) designed to assist you with writing & maintaining code and other text-based content, by enabling LLMs and connecting with MCP servers.
  When entering a query,
  •  Type /help to see the / commands available.
  •  Press Alt-Enter or Option-Enter to start multi-line editing.

Auto-loading MCP servers: echo
  INIT MCP connection: https://echo.mcp.inevitable.fyi/mcp
  FOUND 1 tools
  ADDED function: echo

QUERY >
```