### PR TITLE
Add class / type doc line to fix lint warnings

### DIFF
--- a/src/enkaidu/cli/console_renderer.cr
+++ b/src/enkaidu/cli/console_renderer.cr
@@ -2,6 +2,7 @@ require "../session_renderer"
 require "markterm"
 
 module Enkaidu::CLI
+  # This class is responsible for rendering console outputs.
   class ConsoleRenderer < SessionRenderer
     property? streaming = false
 

--- a/src/enkaidu/cli/options.cr
+++ b/src/enkaidu/cli/options.cr
@@ -4,6 +4,7 @@ require "../session_options"
 require "../config"
 
 module Enkaidu::CLI
+  # This class handles the options for the command-line interface.
   class Options < SessionOptions
     @options = {} of Symbol => String
 

--- a/src/enkaidu/config.cr
+++ b/src/enkaidu/config.cr
@@ -1,11 +1,13 @@
 require "./config_serializable"
 
 module Enkaidu
-  # Configuration
+  # Configuration class facilitates settings for the Enkaidu application.
   class Config < ConfigSerializable
     # ---------------------- start of content definition
 
+    # Represents a Language Model configuration within the Enkaidu application.
     class LLM < ConfigSerializable
+      # Represents a Model within an LLM.
       class Model < ConfigSerializable
         getter name : String
         getter model : String
@@ -18,19 +20,23 @@ module Enkaidu
       getter env = {} of String => String
     end
 
+    # Configuration for the MCP Server.
     class MCPServer < ConfigSerializable
       getter url : String
       getter transport : String = "auto"
       getter bearer_auth_token : String?
     end
 
+    # Global configuration settings for Enkaidu.
     class Global < ConfigSerializable
       getter? trace_mcp = false
       getter? streaming = false
       getter? enable_shell_command = true
     end
 
+    # Session configuration settings for Enkaidu.
     class Session < ConfigSerializable
+      # Configuration for auto-loading settings within a Session.
       class AutoLoad < ConfigSerializable
         getter mcp_servers : Array(String) = [] of String
       end

--- a/src/enkaidu/recorder.cr
+++ b/src/enkaidu/recorder.cr
@@ -1,11 +1,14 @@
 module Enkaidu
+  # Recorder class handles recording in-app events and debug events for troubleshooting LLM comms
   class Recorder
     FLUSH_AFTER = 10
     private getter rec_io : IO?
     private getter count_since_flush = 0
 
+    # Initializes a new Recorder instance with an optional IO object for recording.
     def initialize(@rec_io = nil); end
 
+    # Appends a string to the rec_io. Flushes if threshold is reached.
     def <<(s)
       return unless io = rec_io
       io.puts s
@@ -14,12 +17,14 @@ module Enkaidu
       flush
     end
 
+    # Flushes the rec_io.
     def flush
       return unless io = rec_io
       io.flush
       @count_since_flush = 0
     end
 
+    # Closes the rec_io.
     def close
       return unless io = rec_io
       io.close

--- a/src/enkaidu/session_options.cr
+++ b/src/enkaidu/session_options.cr
@@ -1,8 +1,8 @@
 require "./session_renderer"
 require "./config"
 
-# Defines configurable options for an Enkaidu session
 module Enkaidu
+  # Defines configurable options for an Enkaidu session
   abstract class SessionOptions
     abstract def provider_type : String?
     abstract def model_name : String?

--- a/src/enkaidu/session_renderer.cr
+++ b/src/enkaidu/session_renderer.cr
@@ -1,6 +1,7 @@
-# Defines callbacks from the app session
-# so that we can implement different rendering systems
 module Enkaidu
+  # SessionRenderer defines the interface for rendering session output and
+  # user prompts within the Enkaidu application. These are callbacks from the app session
+  # so that we can implement different rendering systems.
   abstract class SessionRenderer
     abstract def info_with(message, help = nil, markdown = false)
 

--- a/src/llm/azure_openai/chat_connection.cr
+++ b/src/llm/azure_openai/chat_connection.cr
@@ -4,6 +4,8 @@ require "uri"
 require "../openai"
 
 module LLM::AzureOpenAI
+  # `ChatConnection` is a class that extends from `OpenAI::ChatConnection` to provide
+  # specialized connection handling for Azure OpenAI services.
   class ChatConnection < OpenAI::ChatConnection
     def api_ver
       ENV["AZURE_OPENAI_API_VER"]

--- a/src/llm/chat.cr
+++ b/src/llm/chat.cr
@@ -3,6 +3,7 @@ require "./function"
 module LLM
   alias ChatEvent = NamedTuple(type: String, content: JSON::Any)
 
+  # `Chat` is an abstract class that serves as a base for creating various chat implementations.
   abstract class Chat
     getter model : String | Nil = nil
     getter system_message : String | Nil = nil

--- a/src/llm/chat_connection.cr
+++ b/src/llm/chat_connection.cr
@@ -4,6 +4,8 @@ require "uri"
 require "./chat"
 
 module LLM
+  # `ChatConnection` is an abstract class that defines the basic structure
+  # for chat connection implementations.
   abstract class ChatConnection
     protected property model : String? = nil
 

--- a/src/llm/ollama/chat_connection.cr
+++ b/src/llm/ollama/chat_connection.cr
@@ -4,6 +4,8 @@ require "uri"
 require "../openai"
 
 module LLM::Ollama
+  # `ChatConnection` is a class that extends from `OpenAI::ChatConnection` to provide
+  # specialized connection handling with local AI models run using Ollama.
   class ChatConnection < OpenAI::ChatConnection
     protected def url : String
       ENV.fetch("OLLAMA_ENDPOINT", "http://localhost:11434")

--- a/src/llm/openai/chat_connection.cr
+++ b/src/llm/openai/chat_connection.cr
@@ -2,6 +2,8 @@ require "./chat"
 require "../chat_connection"
 
 module LLM::OpenAI
+  # `ChatConnection` is a class extending `LLM::ChatConnection` to implement specific behaviors
+  # for OpenAI's chat services.
   class ChatConnection < LLM::ChatConnection
     def new_chat(&) : LLM::Chat
       chat = Chat.new(self)

--- a/src/llm/param_type.cr
+++ b/src/llm/param_type.cr
@@ -1,4 +1,6 @@
 module LLM
+  # `ParamTypeException` is a custom exception that is raised for invalid parameter types
+  # within the application.
   class ParamTypeException < Exception; end
 
   # The `ParamType` defines an enumeration of supported types for

--- a/src/main.cr
+++ b/src/main.cr
@@ -6,6 +6,7 @@ require "./sucre/command_parser"
 require "option_parser"
 
 module Enkaidu
+  # `Main` is the entry point for executing the application, managing initialization and execution flow.
   class Main
     private getter session
     private getter? done = false

--- a/src/mcpc/sensitive_data.cr
+++ b/src/mcpc/sensitive_data.cr
@@ -1,3 +1,4 @@
+# `SensitiveData` is a generic class to handle and encapsulate sensitive data securely.
 class SensitiveData(T)
   getter label : String
   private getter value : T

--- a/src/mcpc/transport.cr
+++ b/src/mcpc/transport.cr
@@ -6,6 +6,8 @@ require "json"
 module MCPC
   alias AuthToken = SensitiveData(String)
 
+  # `UnsupportedTransportError` is an exception raised when attempting to use a transport mechanism
+  # that is not supported or implemented.
   class UnsupportedTransportError < Exception
   end
 

--- a/src/mcpc/transport_type.cr
+++ b/src/mcpc/transport_type.cr
@@ -1,6 +1,8 @@
 module MCPC
+  # `TransportTypeException` is raised for invalid transport types.
   class TransportTypeException < Exception; end
 
+  # `TransportType` enumerates the possible transport mechanisms available in the system.
   enum TransportType
     AutoDetect
     LegacySSE

--- a/src/tools/create_directory_tool.cr
+++ b/src/tools/create_directory_tool.cr
@@ -17,6 +17,7 @@ class CreateDirectoryTool < LLM::LocalFunction
 
   runner Runner
 
+  # The `Runner` class executes the logic to create directories within the specified constraints.
   class Runner < LLM::Function::Runner
     include FileHelper
 

--- a/src/tools/regex_edit_tool.cr
+++ b/src/tools/regex_edit_tool.cr
@@ -24,9 +24,9 @@ class RegexTextEditTool < LLM::LocalFunction
     include FileHelper
 
     def execute(args : JSON::Any) : String
-      file_path = args["file_path"].as_s? || return error_response("The required file_path was not specified")
-      pattern = args["pattern"].as_s? || return error_response("The required pattern was not specified")
-      replacement = args["replacement"].as_s? || return error_response("The required replacement was not specified")
+      file_path = args["file_path"]?.try &.as_s? || return error_response("The required file_path was not specified")
+      pattern = args["pattern"]?.try &.as_s? || return error_response("The required pattern was not specified")
+      replacement = args["replacement"]?.try &.as_s? || return error_response("The required replacement was not specified")
 
       resolved_path = resolve_path(file_path)
 

--- a/src/tools/replace_text_file_tool.cr
+++ b/src/tools/replace_text_file_tool.cr
@@ -26,9 +26,9 @@ class ReplaceTextInTextFileTool < LLM::LocalFunction
     include FileHelper
 
     def execute(args : JSON::Any) : String
-      file_path = args["file_path"].as_s? || return error_response("The required file_path was not specified")
-      search_text = args["search_text"].as_s? || return error_response("The required search_text was not specified")
-      replacement_text = args["replacement_text"].as_s? || return error_response("The required replacement_text was not specified")
+      file_path = args["file_path"]?.try &.as_s? || return error_response("The required file_path was not specified")
+      search_text = args["search_text"]?.try &.as_s? || return error_response("The required search_text was not specified")
+      replacement_text = args["replacement_text"]?.try &.as_s? || return error_response("The required replacement_text was not specified")
 
       resolved_path = resolve_path(file_path)
 

--- a/src/tools/shell_command_tool.cr
+++ b/src/tools/shell_command_tool.cr
@@ -6,8 +6,10 @@ require "../enkaidu/session_renderer"
 # The `ShellCommandTool` class defines a tool for executing shell commands within the
 # current project directory. Note: This implementation assumes a protected environment (e.g., chroot).
 class ShellCommandTool < LLM::LocalFunction
+  # The `PermissionError` class is raised when user permission is required and denied for executing a command.
   class PermissionError < Exception; end
 
+  # The `SafetyError` class is used to indicate that a command is unsafe for execution due to its content.
   class SafetyError < Exception; end
 
   UNSAFE_STRINGS = ["..", "|", "<", ">", ";", "&"]


### PR DESCRIPTION
So many warnings about missing doc string for classes and types ... all fixed now. (The hard ones are left, which I'll fix separately.)