### PR TITLE
provide better error message for invalid server name

### DIFF
--- a/src/main.cr
+++ b/src/main.cr
@@ -111,9 +111,11 @@ module Enkaidu
       if (config = opts.config).nil?
         raise ArgumentError.new("'#{C_USE_MCP}' with a non-URL argument requires MCP servers to be defined in config.")
       end
+      unless config.mcp_servers.has_key?(name)
+        raise ArgumentError.new("MCP server '#{name}' is not defined in the config file.")
+      end
 
       mcp_server = config.mcp_servers[name]
-      raise ArgumentError.new("MCP server '#{name}' is not defined in the config file.") if mcp_server.nil?
 
       url = mcp_server.url
       auth_token = auth_token_for_bearer_token(url, mcp_server.bearer_auth_token)


### PR DESCRIPTION
- fix #24 

Now it looks like this:

```
QUERY > /use_mcp enkaidu
MCP server 'enkaidu' is not defined in the config file.

  /use_mcp <URL|NAME> [auth_env=<ENVARNAME>] [transport=auto|legacy|http]
  •  Connect with the specified MCP server and register any available tools for use with subsequent queries
  •  MCP server can be specified with URL or name from the config file
  •  if NAME is specified, auth_env and transport may not be specified
  •  Optionally specify name of environment variable that contains the authentication token if needed.
  •  Optionally specify the transport type; defaults to auto
```