### PR TITLE
bump markterm for dark mode fix in 0.6.2

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -26,7 +26,7 @@ shards:
 
   markterm:
     git: https://github.com/ralsina/markterm.git
-    version: 0.5.2
+    version: 0.6.2
 
   pcf-parser:
     git: https://github.com/l3kn/pcf-parser.git


### PR DESCRIPTION
Markterm has a fix for a dark mode issue in 0.6.0 (latest release is 0.6.2).

- bump markterm version to get the fix