### PR TITLE
Fix autoload of some MCP servers causing Enkaidu to hang before starting web server

### DIFF
--- a/src/enkaidu/wui/event_renderer.cr
+++ b/src/enkaidu/wui/event_renderer.cr
@@ -118,8 +118,10 @@ module Enkaidu::WUI
     def initialize(@work_channel); end
 
     private def post_event(event)
+      queue_size_before_post = queue.size
       queue.push(event)
-      work_channel.send(Work::RenderEventPosted)
+      # Only signal channel if first event
+      work_channel.send(Work::RenderEventPosted) if queue_size_before_post.zero?
     end
 
     def event?


### PR DESCRIPTION
The event renderer was signalling a sparse channel for every event when it only needs to signal once when adding to an empty queue. 

Should fix #47 