### PR TITLE
Add config property to select system prompt by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,8 @@ The configuration file is structured in several key sections. Here’s an overvi
   - **model** _(optional)_: Defines the model used for the session, e.g., `gpt4`. When defining `llms` in the configuration, this can be the name of a model and there is no need for the above **provide_type** property.
   - **recording_file** _(optional)_: Path to a file where session recordings are saved.
   - **input_history_file** _(optional)_: Path to a file for saving input history.
-  - **system_prompt** _(optional)_: Custom system prompt for the session.
+  - ~~_system_prompt_~~ _(optional)_: Custom system prompt for the session - **deprecated**.
+  - **system_prompt_name** _(optional)_: Specify the session's system prompt by using the name of the system prompt template.
   - **auto_load** _(optional)_: Contains settings for automatically loading specific resources.
     - **mcp_servers** _(optional)_: List of MCP servers to automatically connect to on startup.
     - **toolsets** _(optional)_: List of toolsets to automatically load, where each toolset can be specified by name to load all tools, or as a map of `name:` and `select:` to specify the tools to load from the named toolset.

--- a/src/enkaidu/config.cr
+++ b/src/enkaidu/config.cr
@@ -47,6 +47,7 @@ module Enkaidu
       getter input_history_file : String?
       getter auto_load : AutoLoad?
       getter system_prompt : String?
+      getter system_prompt_name : String?
     end
 
     class SystemPrompt < ConfigSerializable

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -123,6 +123,7 @@ module Enkaidu
       return from_env unless from_config = opts.config.try(&.session).try(&.system_prompt)
 
       renderer.info_with("INFO: Using system prompt from config file; #{from_config.size} characters")
+      renderer.warning_with("WARN: The `system_prompt` property in config is deprecated. Use `system_prompt_name` instead.")
       from_config
     end
 

--- a/src/enkaidu/session/auto_load.cr
+++ b/src/enkaidu/session/auto_load.cr
@@ -11,45 +11,62 @@ module Enkaidu
           if mcp_servers = config.mcp_servers
             if (mcp_server_names = auto_load.mcp_servers) && mcp_server_names.present?
               renderer.info_with("INFO: Auto-loading MCP servers: #{mcp_server_names.join(", ")}")
-              auto_load_mcp_servers(mcp_servers, mcp_server_names)
+              load_mcp_servers(mcp_servers, mcp_server_names)
             end
           end
 
           if (toolsets = auto_load.toolsets) && toolsets.present?
             renderer.info_with("INFO: Auto-loading toolsets: #{toolsets.join(", ")}")
-            auto_load_toolsets(toolsets)
+            load_toolsets(toolsets)
           end
         end
 
-        unless (prompts = opts.profile.prompts).empty?
-          renderer.info_with("INFO: Auto-loading profile prompts: #{prompts.keys.join(", ")}")
-          auto_load_config_prompts(prompts, origin: "Enkaidu/Profile")
-        end
+        auto_load_config_prompts(config)
+        auto_load_system_prompts(config)
+      end
 
-        if prompts = config.prompts
-          renderer.info_with("INFO: Auto-loading config prompts: #{prompts.keys.join(", ")}")
-          auto_load_config_prompts(prompts, origin: "Enkaidu/Config")
-        end
-
+      private def auto_load_system_prompts(config)
         unless (sys_prompts = opts.profile.system_prompts).empty?
           renderer.info_with("INFO: Auto-loading profile system prompts: #{sys_prompts.keys.join(", ")}")
-          auto_load_system_prompts(sys_prompts, origin: "Enkaidu/Profile")
+          load_system_prompts(sys_prompts, origin: "Enkaidu/Profile")
         end
 
         if sys_prompts = config.system_prompts
           renderer.info_with("INFO: Auto-loading system prompts: #{sys_prompts.keys.join(", ")}")
-          auto_load_system_prompts(sys_prompts, origin: "Enkaidu/Config")
+          load_system_prompts(sys_prompts, origin: "Enkaidu/Config")
+        end
+
+        if session = config.session
+          if name = session.system_prompt_name
+            if session.system_prompt
+              renderer.warning_with("WARN: Deprecated `system_prompt` config property has priority over `system_prompt_name`")
+            elsif sys_prompt = render_system_prompt(name)
+              @chat.with_system_message(sys_prompt)
+            end
+          end
         end
       end
 
-      private def auto_load_system_prompts(sys_prompts, origin = nil)
+      private def auto_load_config_prompts(config)
+        unless (prompts = opts.profile.prompts).empty?
+          renderer.info_with("INFO: Auto-loading profile prompts: #{prompts.keys.join(", ")}")
+          load_config_prompts(prompts, origin: "Enkaidu/Profile")
+        end
+
+        if prompts = config.prompts
+          renderer.info_with("INFO: Auto-loading config prompts: #{prompts.keys.join(", ")}")
+          load_config_prompts(prompts, origin: "Enkaidu/Config")
+        end
+      end
+
+      private def load_system_prompts(sys_prompts, origin = nil)
         sys_prompts.each do |name, sys_prompt|
           tp = TemplatePrompt.new(name, sys_prompt, self, origin: origin)
           register_system_prompt_by_name(name, tp)
         end
       end
 
-      private def auto_load_config_prompts(prompts, origin = nil)
+      private def load_config_prompts(prompts, origin = nil)
         prompts.each do |name, prompt|
           tp = TemplatePrompt.new(name, prompt, self, origin: origin)
           config_prompts << tp
@@ -57,15 +74,14 @@ module Enkaidu
         end
       end
 
-      private def auto_load_mcp_servers(mcp_servers, mcp_server_names)
+      private def load_mcp_servers(mcp_servers, mcp_server_names)
         mcp_server_names.each do |mcp_name|
           mcp_name = mcp_name.strip
-
           use_mcp_by(mcp_name)
         end
       end
 
-      private def auto_load_toolsets(toolsets)
+      private def load_toolsets(toolsets)
         toolsets.each do |toolset|
           if toolset.is_a? String
             load_toolset_by(toolset.strip)


### PR DESCRIPTION
### What?

- Adds support for config session property to select system prompt by name
  - This selects from system prompts defined in config or profile (see #71)
- Keeps the existing `system_prompt` property but it is now **deprecated**.
  - If both are specified, the old property gets priority for backwards compatibility
  - If the old one is specific, a warning is generated

### Why?

The system prompt definitions use templating and can be more dynamic based on profile variables and system properties. It's _just better_.

### Example

```yaml
session:
  system_prompt_name: dev_short
```

Closed #75 