### PR TITLE
Support inclusions with local prompts (not mcp prompts)

### DIFF
--- a/src/enkaidu/session/prompts.cr
+++ b/src/enkaidu/session/prompts.cr
@@ -44,10 +44,11 @@ module Enkaidu
         prompts_by_name[prompt_name]?
       end
 
-      def use_prompt(prompt_name, response_schema : LLM::ResponseSchema? = nil)
+      def use_prompt(prompt_name, attach : LLM::ChatInclusions? = nil, response_schema : LLM::ResponseSchema? = nil)
         if prompt = find_prompt?(prompt_name)
           case prompt
           when MCPPrompt
+            renderer.warning_with("WARN: Including attachments not supported for MCP prompts. Sorry.") if attach
             arg_inputs = renderer.mcp_prompt_ask_input(prompt)
             unless (prompt_result = prompt.render(arg_inputs)).nil?
               text_count = 0
@@ -59,7 +60,7 @@ module Enkaidu
           when TemplatePrompt
             arg_inputs = renderer.user_prompt_ask_input(prompt)
             prompt_text = prompt.render(arg_inputs, profile: opts.profile)
-            ask(query: prompt_text, response_json_schema: response_schema, render_query: true)
+            ask(query: prompt_text, attach: attach, response_json_schema: response_schema, render_query: true)
           end
         end
       rescue ex

--- a/src/enkaidu/slash/prompt.cr
+++ b/src/enkaidu/slash/prompt.cr
@@ -34,8 +34,8 @@ module Enkaidu::Slash
         session.list_prompt_details((cmd.arg_at? 2).as(String))
       elsif cmd.expect?(NAME, "use", String)
         schema = commander.take_response_schema!
-        # Ignore the inclusions
-        session.use_prompt((cmd.arg_at? 2).as(String), response_schema: schema)
+        inclusions = commander.take_inclusions!
+        session.use_prompt(prompt_name: (cmd.arg_at? 2).as(String), attach: inclusions, response_schema: schema)
       else
         session.renderer.warning_with(
           "ERROR: Unknown or incomplete sub-command: #{cmd.arg_at? 0}",


### PR DESCRIPTION
When MCP and user-defined prompts were added (#54) inclusions were not used by prompts. 

This PR enables the use of inclusions for user-defined prompts only.