### PR TITLE
Fix to not ask user when prompt has no args

### DIFF
--- a/src/enkaidu/wui/event_renderer.cr
+++ b/src/enkaidu/wui/event_renderer.cr
@@ -135,6 +135,8 @@ module Enkaidu::WUI
     end
 
     def mcp_prompt_ask_input(prompt : MCPPrompt) : Hash(String, String)
+      return {} of String => String unless (args = prompt.arguments) && args.size.positive?
+
       input_id = Random::Secure.hex(16)
       input_channel = InputsChannel.new
       pending_inputs[input_id] = input_channel
@@ -148,6 +150,8 @@ module Enkaidu::WUI
     end
 
     def user_prompt_ask_input(prompt : TemplatePrompt) : Hash(String, String)
+      return {} of String => String unless (args = prompt.arguments) && args.size.positive?
+
       input_id = Random::Secure.hex(16)
       input_channel = InputsChannel.new
       pending_inputs[input_id] = input_channel


### PR DESCRIPTION
The web UI was prompting the user with an empty dialog box; fixed to not to send an input request.