### PR TITLE
Report elapsed time when user query fully finishes

### DIFF
--- a/src/enkaidu/cli/console_renderer.cr
+++ b/src/enkaidu/cli/console_renderer.cr
@@ -50,6 +50,10 @@ module Enkaidu::CLI
       err_puts_text help, markdown
     end
 
+    def time_elapsed(duration : Time::Span, label : String? = nil)
+      puts "#{label}#{duration.total_seconds.format(decimal_places: 3, only_significant: true)}s elapsed.".colorize(:yellow)
+    end
+
     def user_query_text(query, via_macro = false)
       color = via_macro ? :magenta : :yellow
       prefix0 = "QUERY > ".colorize(color)
@@ -102,10 +106,11 @@ module Enkaidu::CLI
     LLM_MAX_TOOL_CALL_ARGS_LENGTH = 72
 
     def llm_tool_call(name, args)
+      puts if streaming?
       print "  CALL".colorize(:green)
       puts " #{name.colorize(:red)} " \
            "with #{trim_text(args.to_s, LLM_MAX_TOOL_CALL_ARGS_LENGTH).colorize(:red)}"
-      puts
+      puts unless streaming?
     end
 
     def llm_error(err)
@@ -122,9 +127,9 @@ module Enkaidu::CLI
     end
 
     def llm_text_block(text, reasoning : Bool)
-      puts "┌─ ─ ─ ─<#{"reasoning".colorize(:dark_gray).italic}>─ ─ ─ ─ ─ ─ " if reasoning
+      puts "╭╶╶╶╶╶╶╶╶╶╶<#{"reasoning".colorize(:dark_gray).italic}>╶╶╶╶╶╶╶╶╶╶╶" if reasoning
       puts Markd.to_term(text)
-      puts "└─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ " if reasoning
+      puts "╰╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶" if reasoning
       puts
     end
 

--- a/src/enkaidu/session_renderer.cr
+++ b/src/enkaidu/session_renderer.cr
@@ -19,6 +19,8 @@ module Enkaidu
 
     abstract def user_prompt_ask_input(prompt : TemplatePrompt) : Hash(String, String)
 
+    abstract def time_elapsed(duration : Time::Span, label : String? = nil)
+
     abstract def session_reset
     abstract def session_pushed(depth, keep_tools, keep_prompts, keep_history)
     abstract def session_popped(depth)

--- a/src/enkaidu/wui/event_renderer.cr
+++ b/src/enkaidu/wui/event_renderer.cr
@@ -48,6 +48,10 @@ module Enkaidu::WUI
       post_event Render::ErrorMessage.new(message, details: help.to_s, markdown: markdown)
     end
 
+    def time_elapsed(duration : Time::Span, label : String? = nil)
+      info_with("#{label}#{duration.total_seconds}s elapsed.")
+    end
+
     def user_query_text(query, via_macro = false)
       post_event Render::Query.new(Render::ContentType::Text, query, via_macro)
     end


### PR DESCRIPTION
### What?

Show elapsed time when a user's query fully completes; it's a good way to measure how long the model took to answer the question.

### Why?

For fun. And sometimes helps to compare different models and engines etc.