### PR TITLE
Fix session `pop_and_take` to only erase parent history on reset

### DIFF
--- a/release_notes/v0.8.7_in_progress.md
+++ b/release_notes/v0.8.7_in_progress.md
@@ -11,8 +11,8 @@
 
 #### FIXES
 
-> N/a
+> Fixed `/session pop_and_take` with used with `reset_parent=yes` to **only** erase the parent session's history without resetting anything else. Other aspects of the sessions (tools, prompts, system prompt, model, etc) remain unchanged.
 
 #### MISC
 
-> N/a
+> Refactored `src/llm` to rename `Session` with `History`, and simplify method names.

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -92,7 +92,7 @@ module Enkaidu
                               render_system_prompt(system_prompt_name)
                             end
       @chat = setup_chat(override_sys_prompt)
-      chat.fork_session(fork_from.chat) if keep_history
+      chat.fork(fork_from.chat) if keep_history
 
       if keep_tools
         @mcp_functions = fork_from.mcp_functions.dup
@@ -232,7 +232,7 @@ module Enkaidu
     end
 
     def transfer_tail_chats(to : Session, num = 1, filter_by_role : String? = nil)
-      chat.send_tail_session(to: to.chat, num_responses: num, filter_by_role: filter_by_role)
+      chat.send_tail(to: to.chat, num_responses: num, filter_by_role: filter_by_role)
     end
   end
 end

--- a/src/enkaidu/session/lifecycle.cr
+++ b/src/enkaidu/session/lifecycle.cr
@@ -34,7 +34,7 @@ module Enkaidu
 
         # load chat session
         sess = io.gets.as(String)
-        @chat.load_session(sess)
+        @chat.load(sess)
         tail_session_events(tail_num_chats)
       end
 
@@ -58,6 +58,11 @@ module Enkaidu
         end
       end
 
+      # Reset session history without affecting any other configuration.
+      def erase_history
+        @chat.erase_history
+      end
+
       # Save session to a JSONL file,  where each line in order is as follows:
       #   - about the file / app
       #   - active MCP server connection info
@@ -70,7 +75,7 @@ module Enkaidu
         save_active_mcp_servers(io)
         save_active_toolsets(io)
 
-        chat.save_session(io)
+        chat.save(io)
         io.puts
       end
 
@@ -135,7 +140,7 @@ module Enkaidu
 
       private def tail_session_events(num_chats)
         text_count = 0
-        @chat.tail_session(num_chats) do |chat_ev|
+        @chat.tail(num_chats) do |chat_ev|
           text_count = render_session_event chat_ev, text_count
         end
       end

--- a/src/enkaidu/session_stack.cr
+++ b/src/enkaidu/session_stack.cr
@@ -28,11 +28,11 @@ module Enkaidu
         system_prompt_name: system_prompt_name)
     end
 
-    def pop_session(transfer_last_num = 0, filter_by_role : String? = nil, reset_parent = false, &) : Bool
+    def pop_session(transfer_last_num = 0, filter_by_role : String? = nil, reset_history = false, &) : Bool
       if @session_stack.size > 1
         prev = @session_stack.pop
         yield true # Notify to indicate we're back in the parent session
-        session.reset_session(nil) if reset_parent
+        session.erase_history if reset_history
         if transfer_last_num.positive?
           prev.transfer_tail_chats(to: session, num: transfer_last_num,
             filter_by_role: filter_by_role)

--- a/src/enkaidu/slash/session.cr
+++ b/src/enkaidu/slash/session.cr
@@ -39,7 +39,7 @@ module Enkaidu::Slash
       - Throws away current chat session and restore last pushed (parent) chat session (if any)
     - `pop_and_take [response_only=yes|no] [reset_parent=yes|no]`
       - Throws away current chat session and restore last pushed (parent) chat session (if any), with following caveats:
-        - Resets the restored session if `reset_parent=yes` is specified
+        - Resets the parent's session history if `reset_parent=yes` without affecting any other session configuration.
         - Appends the last chat from the interim session, keeping the both the query and response unless
         `response_only=yes` is specified, in which case only the response is kept.
     HELP1
@@ -193,7 +193,7 @@ module Enkaidu::Slash
     private def handle_session_pop_take(session_stack, cmd)
       filter_role = cmd.arg_named?("response_only", "no").try(&.==("yes")) ? "assistant" : nil
       reset_parent = cmd.arg_named?("reset_parent", "no").try(&.!=("no"))
-      session_stack.pop_session(transfer_last_num: 1, filter_by_role: filter_role, reset_parent: reset_parent) do
+      session_stack.pop_session(transfer_last_num: 1, filter_by_role: filter_role, reset_history: reset_parent) do
         # Render session popped
         session_stack.session.renderer.session_popped(depth: session_stack.depth)
       end

--- a/src/llm/chat.cr
+++ b/src/llm/chat.cr
@@ -72,6 +72,9 @@ module LLM
       @tools_by_name.each_value
     end
 
+    # Erase history but keep connection
+    abstract def erase_history : Nil
+
     abstract def import(prompt : MCP::PromptResult, emit = false, & : ChatEvent ->) : Nil
 
     # Resubmit current session as a query to get another answer
@@ -85,14 +88,18 @@ module LLM
 
     # Replace current session with a "fork" of the session from the given
     # `Chat` instance; may fail if `self` is not compatible.
-    abstract def fork_session(from : Chat) : Nil
+    abstract def fork(from : Chat) : Nil
 
-    abstract def save_session(io : IO | JSON::Builder) : Nil
+    # Save chat history
+    abstract def save(io : IO | JSON::Builder) : Nil
 
-    abstract def load_session(io : IO | String) : Nil
+    # Load chat history
+    abstract def load(io : IO | String) : Nil
 
-    abstract def tail_session(num_responses = 1, & : ChatEvent ->) : Nil
+    # Yield the latest `num_responses` messages from chat history
+    abstract def tail(num_responses = 1, & : ChatEvent ->) : Nil
 
-    abstract def send_tail_session(to : Chat, num_responses = 1, filter_by_role : String = nil) : Nil
+    # Append latest `num_responses` messages to the target chat's history
+    abstract def send_tail(to : Chat, num_responses = 1, filter_by_role : String = nil) : Nil
   end
 end

--- a/src/llm/openai/chat/history.cr
+++ b/src/llm/openai/chat/history.cr
@@ -4,9 +4,9 @@ require "./message"
 require "./usage"
 
 module LLM::OpenAI
-  # The serializable chat session keeps all wrapped messages to save
+  # The serializable chat history keeps all wrapped messages to save
   # the additional information when saving the session.
-  class Session
+  class History
     # This wrapper is used to keep the `Message` and additional information
     # that we want to save when available.
     class MessageWrap
@@ -18,7 +18,7 @@ module LLM::OpenAI
       def initialize(@message, @usage); end
     end
 
-    # The session itself is serializable so we can save a chat session
+    # The history itself is serializable so we can save a chat's history
     include JSON::Serializable
     include JSON::Serializable::Unmapped
 
@@ -29,7 +29,7 @@ module LLM::OpenAI
       @messages = [] of MessageWrap
     end
 
-    def branch(from : Session)
+    def branch(from : History)
       @messages = from.@messages.dup
     end
 
@@ -37,7 +37,7 @@ module LLM::OpenAI
       @messages << MessageWrap.new(msg, usage)
     end
 
-    # This yields each `Message` in the session
+    # This yields each `Message` in the history
     def each_message(&)
       @messages.each do |msgplus|
         yield msgplus.message
@@ -72,7 +72,7 @@ module LLM::OpenAI
       end
     end
 
-    def transfer_tail_chats(to : Session, num = 1, filter_by_role : String? = nil)
+    def transfer_tail_chats(to : History, num = 1, filter_by_role : String? = nil)
       tail_chat_messages(num) do |msgplus|
         msg = msgplus.message
         to.append_message(msg, msgplus.usage) if filter_by_role.nil? || filter_by_role == msg.role


### PR DESCRIPTION
### What?

- Refactored `src/llm` to rename `Session` with `History`, and simplify method names.
- Fixed `/session pop_and_take` with used with `reset_parent=yes` to **only** erase the parent session's history without resetting anything else. Other aspects of the sessions (tools, prompts, system prompt, model, etc) remain unchanged.

### Why?

- Use of `Session` in LLM::Chat was confusing and misleading. 
- When poping back to parent, the goal is to affect the parent session history, not all the session config. 
  - This is the correct behaviour when bringing content back.
