### PR TITLE
Add glob-based file finding tool

### DIFF
--- a/release_notes/v0.8.7_in_progress.md
+++ b/release_notes/v0.8.7_in_progress.md
@@ -5,7 +5,7 @@
 
 #### FEATURES
 
-- None
+- Add `find_files` tool, which finds files by matching a glob pattern, to the `FileManagement` toolset.
 
 #### IMPROVEMENTS
 

--- a/src/tools/file_helper.cr
+++ b/src/tools/file_helper.cr
@@ -5,7 +5,8 @@ module Tools
   class FileLoadingError < Exception; end
 
   module FileHelper
-    DELETED_FILES_PATH = ".deleted_files/"
+    DELETED_FILES_PATH    = ".deleted_files/"
+    MAX_FIND_FILE_MATCHES = 1000
 
     def resolve_path(path)
       File.expand_path(path)
@@ -21,12 +22,20 @@ module Tools
     end
 
     def within_current_directory?(requested_path)
-      current_dir = File.expand_path(".")
-      requested_path.starts_with?(current_dir)
+      requested_path.starts_with?(Dir.current)
     end
 
     def valid_file?(resolved_path)
       File.exists?(resolved_path) && File.file?(resolved_path)
+    end
+
+    def find_files(glob_pattern : String, max = MAX_FIND_FILE_MATCHES)
+      matches = [] of String
+      Dir.glob(glob_pattern) do |path|
+        matches << path
+        break if matches.size >= max
+      end
+      matches
     end
 
     def text_file?(resolved_path)

--- a/src/tools/toolsets/file_management.cr
+++ b/src/tools/toolsets/file_management.cr
@@ -5,6 +5,7 @@ module Tools
   module FileManagement
     toolset = ToolSet.create("FileManagement") do
       hold ListFilesTool
+      hold FindFilesTool
       hold CreateDirectoryTool
       hold RenameFileTool
       hold DeleteFileTool

--- a/src/tools/toolsets/file_management/find_files_tool.cr
+++ b/src/tools/toolsets/file_management/find_files_tool.cr
@@ -1,0 +1,60 @@
+require "json"
+require "../../built_in_function"
+require "../../file_helper"
+
+module Tools::FileManagement
+  # The `FindFilesTool` defines a tool that find and returns all files and folders that match a specific glob pattern.
+  # It ensures the operation is performed securely within the allowed directory,
+  # avoiding access to unauthorized paths.
+  class FindFilesTool < BuiltInFunction
+    name "find_files"
+
+    # Provide a description for the tool
+    description "Finds files and directories that match a specific glob pattern."
+
+    # Define the acceptable parameter using the `param` method
+    param "pattern", required: true,
+      description: "The glob pattern expression with which to find matching files. " \
+                   "Supports wildcards `*`, globstars `**`, branching `{a,n}`, " \
+                   "character ranges [a-z] and negated ranges [^a-z],"
+    param "max", type: Param::Type::Num,
+      description: "Optional, maxmimum number of matches to return (default is #{FileHelper::MAX_FIND_FILE_MATCHES})"
+
+    runner Runner
+
+    # The Runner class executes the function
+    class Runner < LLM::Function::Runner
+      include FileHelper
+
+      def execute(args : JSON::Any) : String
+        pattern = args["pattern"]?.try(&.as_s?) || "*"
+        max = args["max"]?.try(&.as_i?) || MAX_FIND_FILE_MATCHES
+
+        unless within_current_directory?(resolve_path(pattern))
+          return error_response("Looking outside current directory not allowed.")
+        end
+
+        if pattern.includes?("../") || pattern.includes?("/..")
+          return error_response("Reverse path navigation (via `..`) not allowed.")
+        end
+
+        # Move the file to the deleted_files directory
+        begin
+          success_response(find_files(pattern, max))
+        rescue e
+          error_response("An error occurred while finding file: #{e.message}")
+        end
+      end
+
+      # Create a success response as a JSON string
+      private def success_response(matches : Array(String))
+        matches.to_json
+      end
+
+      # Create an error response as a JSON string
+      private def error_response(message)
+        {error: message}.to_json
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What?

Add `find_files` tool, which finds files by matching a glob pattern, to the `FileManagement` toolset.

### Why?

Often when asking for help understanding a project the LLM wants to search for files but ends up using `list_files` over and over again. A glob search would be more efficient.

### Globbing

The implementation used `Dir#glob` which supports glob pattern matching defined by [`Dir#match?`](https://crystal-lang.org/api/1.19.1/File.html#match%3F%28pattern%3AString%2Cpath%3APath%7CString%29%3ABool-class-method):

> The pattern syntax is similar to shell filename globbing. It may contain the following metacharacters:
> 
> * `*`: Wildcard matches zero or more characters, except for directory separators.
> * `**`: Globstar matches zero or more characters, including directory separators.
>   It must match a complete path segment, i.e. it must be wrapped in `/`
>   except for the beginning and end of the pattern.
> * `?`: Matches a single Unicode character, except for directory separators.
> * Character classes:
>   * `[abc]`: Character set matches one of the Unicode characters contained in the brackets.
>   * `[^abc]`: Negated character set matches any Unicode character _except_ those contained in the brackets.
>   * `[a-z]`: Character range matches one Unicode character contained in the character range.
>   * `[^a-z]`: Negated character range matches one Unicode character _except_ those contained in the character range.
> * `{a,b}`: Branches matches one of the subpatterns contained in the braces. Subpatterns
>   may contain any other pattern feature, including nested branches (max nesting depth is 10 levels deep).
> * `\\`: Backslash escapes the next character.
> 
> Multiple character pattern can be combined in the same brackets to define a
> character class (for example: `[0-9a-f]`).
> 
> 