### PR TITLE
Fix `/session` bugs with model selection

### DIFF
--- a/release_notes/v0.8.8-pre-release.md
+++ b/release_notes/v0.8.8-pre-release.md
@@ -13,7 +13,8 @@
 
 #### FIXES
 
-- n/a
+- Fix `/session new TEST model=M` which doesn't report error when `M` doesn't exist
+- Fix `/session push` so that it always uses parent's model, preserving model change in new root sessions.
 
 #### MISC
 


### PR DESCRIPTION
### What?

- Fix `/session new TEST model=M` which doesn't report error when `M` doesn't exist
- Fix `/session push` so that it always uses parent's model, preserving model change in new root sessions.
