### PR TITLE
Pin down dependencies.

### DIFF
--- a/release_notes/v0.8.8-pre-release.md
+++ b/release_notes/v0.8.8-pre-release.md
@@ -18,4 +18,4 @@
 
 #### MISC
 
-- n/a
+- Updated some dependencies, and pinned them down to versions that don't break the build.

--- a/shard.lock
+++ b/shard.lock
@@ -38,11 +38,15 @@ shards:
 
   markd:
     git: https://github.com/icyleaf/markd.git
-    version: 0.5.0
+    version: 0.5.0+git.commit.03cd4f5d6f4e56054502a6548b4c2ff92fb3dc20
 
   markterm:
     git: https://github.com/ralsina/markterm.git
-    version: 0.6.3
+    version: 0.7.0
+
+  progress_bar:
+    git: https://github.com/mgomes/progress_bar.git
+    version: 1.0.1+git.commit.aa5ebab89d31167208387640db06d3964ec7922b
 
   reply:
     git: https://github.com/i3oris/reply.git
@@ -56,9 +60,21 @@ shards:
     git: https://gitlab.com/arctic-fox/spectator.git
     version: 0.12.2
 
+  tablo:
+    git: https://github.com/hutou/tablo.git
+    version: 1.0.2
+
   tartrazine:
     git: https://github.com/ralsina/tartrazine.git
     version: 0.20.1
+
+  textseg:
+    git: https://github.com/naqvis/uni_text_seg.git
+    version: 0.1.3
+
+  uniwidth:
+    git: https://github.com/naqvis/uni_char_width.git
+    version: 0.1.3
 
   xpath2:
     git: https://github.com/naqvis/crystal-xpath2.git

--- a/shard.yml
+++ b/shard.yml
@@ -15,17 +15,22 @@ development_dependencies:
 dependencies:
   liquid:
     github: amberframework/liquid.cr
+    version: 1.0.0
   json-schema:
     github: spider-gazelle/json-schema
+    version: 1.3.2
   markterm:
     github: ralsina/markterm
+    version: 0.7.0
     # --- markterm already pulls in ...
     # baked_file_system:
     #   github: schovi/baked_file_system
   reply:
     github: I3oris/reply
+    version: 0.4.0
   html5:
     github: naqvis/crystal-html5
+    version: 0.5.1
 
 targets:
   enkaidu:


### PR DESCRIPTION
### Why?

Un-pinned dependencies broke Enkaidu build when I updated them. 

### What?

So now I've pinned them down to versions that don't break the build.