### PR TITLE
Fix error calling #to_json on HTTP::Headers

### DIFF
--- a/src/llm/openai/chat.cr
+++ b/src/llm/openai/chat.cr
@@ -215,7 +215,7 @@ module LLM::OpenAI
 
     private def unexpected_response(resp)
       {type: "error/unexpected", content: JSON::Any.new(Hash{
-        "headers" => JSON.parse(resp.headers.to_json),
+        "headers" => JSON.parse(resp.headers.to_h.to_json),
         "body"    => JSON::Any.new(resp.body_io.gets_to_end),
       })}
     end

--- a/src/mcpc/http_legacy_transport.cr
+++ b/src/mcpc/http_legacy_transport.cr
@@ -150,9 +150,9 @@ module MCPC
         unless OK_STATUS.includes? resp.status_code
           yield Hash{
             "type"             => "error",
-            "request_headers"  => JSON.parse(last_request_headers.to_json),
+            "request_headers"  => JSON.parse(last_request_headers.try(&.to_h).to_json),
             "response_status"  => "#{resp.status_code} #{resp.status}",
-            "response_headers" => JSON.parse(resp.headers.to_json),
+            "response_headers" => JSON.parse(resp.headers.to_h.to_json),
             "response_body"    => resp.body_io.gets_to_end,
           }
         end

--- a/src/mcpc/transport.cr
+++ b/src/mcpc/transport.cr
@@ -232,9 +232,9 @@ module MCPC
           # Unknown response for many possible reasons
           yield Hash{
             "type"             => "error",
-            "request_headers"  => JSON.parse(last_request_headers.to_json),
+            "request_headers"  => JSON.parse(last_request_headers.try(&.to_h).to_json),
             "response_status"  => "#{resp.status_code} #{resp.status}",
-            "response_headers" => JSON.parse(resp.headers.to_json),
+            "response_headers" => JSON.parse(resp.headers.to_h.to_json),
             "response_body"    => io.gets_to_end,
           }
         end


### PR DESCRIPTION
Perfect storm, I picked up Crystal 1.20 and looks like `#to_json` has problems with `HTTP::Headers`. 
Only in exception handlers when reporting headers; calling `#to_h` first solves the issue. 