### PR TITLE
Update deps and enable (experimental) streaming markdown rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ enkaidu.yml
 CLAUDE.md
 .enkaidu
 .deleted_files/
+.spectator-failures

--- a/release_notes/v0.9.0-pre.md
+++ b/release_notes/v0.9.0-pre.md
@@ -5,11 +5,6 @@
 - Enkaidu in the console shows the reason for tool calls before the `CALL <tool-name> ...`.
 - Improved rendering _reasoning_ boundaries when streaming to the console
 
-#### IN PROGRESS
-
-- Taking initial steps in streaming mode to gather up text into lines before rendering
-- Markdown rendering needs a stateful incremental line by line renderer ... one day.
-
 #### FEATURES
 
 - Support quiet mode, available  via `--quiet` or `-Q` commandline flag, as well as via session config `quiet:`.
@@ -25,3 +20,4 @@
 - Enable multi-line editing by default, except:
   - `Enter` on a blank line or mid-sentence submits
   - Commands and macros submit immediately
+- Support experimental streaming markdown rendering. While not as good as the one in non-streaming mode, it makes streaming much more enjoyable even with its limitations.

--- a/shard.lock
+++ b/shard.lock
@@ -58,11 +58,7 @@ shards:
 
   tablo:
     git: https://github.com/hutou/tablo.git
-    version: 1.0.2
-
-  tallboy:
-    git: https://github.com/epoch/tallboy.git
-    version: 0.9.3
+    version: 1.1.0
 
   tartrazine:
     git: https://github.com/ralsina/tartrazine.git
@@ -70,7 +66,7 @@ shards:
 
   termify:
     git: https://github.com/nogginly/termify.cr.git
-    version: 0.2.0+git.commit.69f760faa4240400ee9f643456fd5e7f8b22c8d4
+    version: 0.2.1+git.commit.3f51e493820445b5ce7232594536e0fc5060dfa1
 
   textseg:
     git: https://github.com/naqvis/uni_text_seg.git

--- a/shard.lock
+++ b/shard.lock
@@ -66,7 +66,7 @@ shards:
 
   termify:
     git: https://github.com/nogginly/termify.cr.git
-    version: 0.2.1+git.commit.3f51e493820445b5ce7232594536e0fc5060dfa1
+    version: 0.2.1+git.commit.16801f10b82220e568636ba8a994bccf6d7198f0
 
   textseg:
     git: https://github.com/naqvis/uni_text_seg.git

--- a/shard.lock
+++ b/shard.lock
@@ -20,13 +20,9 @@ shards:
     git: https://github.com/ralsina/docopt.cr.git
     version: 0.3.1
 
-  fnv:
-    git: https://github.com/naqvis/crystal-fnv.git
-    version: 0.1.3
-
   html5:
     git: https://github.com/naqvis/crystal-html5.git
-    version: 0.5.1
+    version: 0.7.0
 
   json-schema:
     git: https://github.com/spider-gazelle/json-schema.git
@@ -58,15 +54,23 @@ shards:
 
   spectator:
     git: https://gitlab.com/arctic-fox/spectator.git
-    version: 0.12.2
+    version: 0.12.4
 
   tablo:
     git: https://github.com/hutou/tablo.git
     version: 1.0.2
 
+  tallboy:
+    git: https://github.com/epoch/tallboy.git
+    version: 0.9.3
+
   tartrazine:
     git: https://github.com/ralsina/tartrazine.git
     version: 0.20.1
+
+  termify:
+    git: https://github.com/nogginly/termify.cr.git
+    version: 0.2.0+git.commit.69f760faa4240400ee9f643456fd5e7f8b22c8d4
 
   textseg:
     git: https://github.com/naqvis/uni_text_seg.git
@@ -78,5 +82,5 @@ shards:
 
   xpath2:
     git: https://github.com/naqvis/crystal-xpath2.git
-    version: 0.1.3
+    version: 0.2.0
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,8 @@
 name: enkaidu
 version: 0.9.0-pre
 license: MPL-2.0
-description: Command line tool that can use local and remote AI models to assist with local editing and refinement tasks.
+description: Command line tool that can use local and remote AI models to assist
+  with local editing and refinement tasks.
 authors:
   - nogginly <nogginly@icloud.com>
 repository: https://github.com/enkaidu-dev/enkaidu
@@ -13,6 +14,8 @@ development_dependencies:
     gitlab: arctic-fox/spectator
 
 dependencies:
+  termify:
+    github: nogginly/termify.cr
   liquid:
     github: amberframework/liquid.cr
     version: 1.0.0
@@ -30,7 +33,7 @@ dependencies:
     version: 0.4.0
   html5:
     github: naqvis/crystal-html5
-    version: 0.5.1
+    version: 0.7.0
 
 targets:
   enkaidu:

--- a/src/enkaidu/cli/console_renderer.cr
+++ b/src/enkaidu/cli/console_renderer.cr
@@ -1,4 +1,5 @@
 require "reply"
+require "termify"
 require "../session_renderer"
 
 require "markterm"
@@ -21,6 +22,21 @@ module Enkaidu::CLI
   class ConsoleRenderer < SessionRenderer
     property? streaming = false
     property? quiet = false
+
+    MDR_STYLESHEET = Termify::Markdown::Stylesheet.new({
+      :h1          => {bold: true, prefix: "# ".colorize(:dark_gray).to_s},
+      :h2          => {bold: true, prefix: "## ".colorize(:dark_gray).to_s},
+      :h3          => {bold: true, prefix: "### ".colorize(:dark_gray).to_s},
+      :h4          => {bold: true},
+      :h5          => {bold: true},
+      :h6          => {bold: true},
+      :code_block  => {fg: Termify::ANSI::FG_CYAN, prefix: "░ "},
+      :code_inline => {fg: Termify::ANSI::FG_CYAN},
+      :html_tag    => {dim: true},
+      :block_html  => {dim: true},
+      :table       => {fg: Termify::ANSI::FG_DEFAULT},
+      :block_quote => {prefix: "▌ "},
+    })
 
     private getter input = InputReader.new("> ")
 
@@ -161,57 +177,6 @@ module Enkaidu::CLI
       warning_with("ERROR:\n#{err.to_json}")
     end
 
-    class TextGatherer
-      @sink : IO::Memory
-
-      def initialize
-        @sink = IO::Memory.new
-      end
-
-      def take : String
-        str = @sink.to_s
-        @sink.clear
-        str
-      end
-
-      def wipe
-        @sink.clear
-      end
-
-      delegate :<<, :puts, :print, to: @sink
-    end
-
-    @text_sink = TextGatherer.new
-
-    private def gather_and_render_streaming_text(text, starting : Bool, ending : Bool)
-      # EXPERIMENTAL line gathering
-      puts if starting
-      defer = nil
-      # If fragment has `\n` then split by newline so we can
-      # render the line to newline, and put remainder into the
-      # gatherer to complete as part of the next line
-      if text.includes?('\n')
-        # split and keep LHS
-        parts = text.split('\n', limit: 2)
-        @text_sink << parts.first
-        defer = parts.last # defer RHS
-      else
-        @text_sink << text
-      end
-
-      if defer || ending
-        # We found a newline, or we're done; so render line
-        line = @text_sink.take
-
-        # Plain lines; need a way to gather blocks and render them to
-        # preserve formatting of tables, lists etc.
-        puts line
-
-        # Retain RHS of split for next line
-        @text_sink << defer if defer
-      end
-    end
-
     class Counter
       SPINNER_CHARS = ['|', '/', '-', '\\']
       getter count = 0
@@ -228,6 +193,13 @@ module Enkaidu::CLI
     end
 
     @think_counter = Counter.new
+
+    @md_renderer = Termify::Markdown::Renderer.new(STDOUT, MDR_STYLESHEET)
+
+    private def render_streaming_markdown(text, _starting : Bool, ending : Bool)
+      @md_renderer << text
+      @md_renderer.puts if ending
+    end
 
     def llm_text(text, reasoning : Bool, starting : Bool = false, ending : Bool = false)
       if streaming?
@@ -248,7 +220,8 @@ module Enkaidu::CLI
             puts "", REASONING_FINISH if ending
           end
         else
-          gather_and_render_streaming_text(text, starting, ending)
+          render_streaming_markdown(text, starting, ending)
+          # gather_and_render_streaming_text(text, starting, ending)
         end
       else
         llm_text_block(text, reasoning)

--- a/src/enkaidu/cli/main.cr
+++ b/src/enkaidu/cli/main.cr
@@ -23,7 +23,7 @@ module Enkaidu::CLI
 
     WELCOME_FIRST_LEFT  = "│ Enkaidu #{VERSION} │ /help for commands │ Multi-line input │ Tab to auto-complete"
     WELCOME_SECOND_LEFT = "│ Welcome to your second-in-command(-line) agentic assistant for AI that YOU control!"
-    WELCOME_THIRD_LEFT  = "│ FYI │ Markdown formatted rendering is not available when streaming. Soon."
+    WELCOME_THIRD_LEFT  = "│ FYI │ Markdown rendering is experimental when streaming."
 
     WELCOME_WIDTH = [WELCOME_FIRST_LEFT.size, WELCOME_SECOND_LEFT.size, WELCOME_THIRD_LEFT.size].max
 
@@ -33,7 +33,7 @@ module Enkaidu::CLI
 
     WELCOME_FIRST_COLOR = "│ #{"Enkaidu".colorize.bold} #{VERSION} │ " \
                           "#{"/help".colorize(:yellow)} for commands │ Multi-line input │ #{"Tab".colorize(:yellow)} to auto-complete"
-    WELCOME_THIRD_COLOR = "│ #{"FYI".colorize.bold} │ Markdown formatted rendering is not available when streaming. Soon."
+    WELCOME_THIRD_COLOR = "│ #{"FYI".colorize.bold} │ Markdown rendering is #{"experimental".colorize.bold} when streaming."
     WELCOME_QUIET_BAR   = "─" * (WELCOME_FIRST_LEFT.size + WELCOME_FIRST_RIGHT.size - 2)
 
     PROMPT_PRERELEASE = "CAUTION! #{VERSION} is a PRE-RELEASE in development.".colorize(:red)


### PR DESCRIPTION
### What?

- Update `html5` shard to latest
- Add `termify` shard and 
- Use `Termify::Markdown::Renderer` to enable rendering streaming markdown
  - Indicate it's experimental if streaming enabled

### Why?

- With agents there's often a lot of big answers or data, and waiting for all to be done can get slow with local models
- Streaming works but we need to support Markdown rendering

### Experimental?

- `termify` is a work in progress. It's good enough to start using, but not done enough to say nothing.