### PR TITLE
Remove deprecated `/session pop_and_take`

### DIFF
--- a/release_notes/v0.9.0-pre.md
+++ b/release_notes/v0.9.0-pre.md
@@ -21,3 +21,7 @@
   - `Enter` on a blank line or mid-sentence submits
   - Commands and macros submit immediately
 - Support experimental streaming markdown rendering. While not as good as the one in non-streaming mode, it makes streaming much more enjoyable even with its limitations.
+
+#### REMOVED
+
+- Previously deprecated `/session pop_and_take` command is now removed. Use `/session pop retain=...`, it's better.

--- a/src/enkaidu/session_stack.cr
+++ b/src/enkaidu/session_stack.cr
@@ -61,19 +61,5 @@ module Enkaidu
       end
       false
     end
-
-    def pop_session_deprecated(transfer_last_num = 0, filter_by_role : String? = nil, reset_history = false, &) : Bool
-      if @session_stack.size > 1
-        prev = @session_stack.pop
-        yield true # Notify to indicate we're back in the parent session
-        session.erase_history if reset_history
-        if transfer_last_num.positive?
-          prev.transfer_tail_chats(to: session, num: transfer_last_num,
-            filter_by_role: filter_by_role)
-        end
-        return true
-      end
-      false
-    end
   end
 end

--- a/src/enkaidu/slash/session.cr
+++ b/src/enkaidu/slash/session.cr
@@ -44,11 +44,6 @@ module Enkaidu::Slash
         - Retain some of the chat history if `retain=` specified, otherwise `none` and
         - Replace parent chat history if `replace=yes`, otherwise `no`
       - Without parameters, throws away session history
-    - (DEPRECATED) `pop_and_take [response_only=yes|no] [reset_parent=yes|no]`
-      - Throws away current chat session and restore last pushed (parent) chat session (if any), with following caveats:
-        - Resets the parent's session history if `reset_parent=yes` without affecting any other session configuration.
-        - Appends the last chat from the interim session, keeping the both the query and response unless
-        `response_only=yes` is specified, in which case only the response is kept.
     HELP1
 
     def name : String
@@ -107,9 +102,6 @@ module Enkaidu::Slash
         handle_session_push(current_session_stack, cmd)
       when .expect?(NAME, "pop", retain: SESSION_POP_RETAIN_NIL, replace: YES_NO_NIL)
         handle_session_pop_with(current_session_stack, cmd)
-      when .expect?(NAME, "pop_and_take",
-        response_only: YES_NO_NIL, reset_parent: YES_NO_NIL)
-        handle_session_pop_take(current_session_stack, cmd)
       else
         session.renderer.warning_with("WARNING: Unknown or incomplete sub-command: '#{cmd.input}'",
           help: HELP, markdown: true)
@@ -217,20 +209,6 @@ module Enkaidu::Slash
       retain = cmd.arg_named?("retain", "none").try(&.to_s)
       replace_history = cmd.arg_named?("replace", "no").try(&.!=("no"))
       session_stack.pop_session(SessionStack::Retain.parse(retain), replace_history) do
-        # Render session popped
-        session_stack.session.renderer.session_popped(depth: session_stack.depth)
-      end
-    end
-
-    # Deprecate this.
-    private def handle_session_pop_take(session_stack, cmd)
-      session_stack.session.renderer.warning_with("WARN: DEPRECATED COMMAND: /session pop_and_take")
-
-      filter_role = cmd.arg_named?("response_only", "no").try(&.==("yes")) ? "assistant" : nil
-      reset_parent = cmd.arg_named?("reset_parent", "no").try(&.!=("no"))
-      session_stack.pop_session_deprecated(transfer_last_num: 1,
-        filter_by_role: filter_role,
-        reset_history: reset_parent) do
         # Render session popped
         session_stack.session.renderer.session_popped(depth: session_stack.depth)
       end


### PR DESCRIPTION
Deprecated this a while back and indicated would remove in 0.9.0.

It's now 0.9.0-pre and time to remove `/session pop_and_take`. We don't need it any more.