### PR TITLE
Core system prompt, configurable console style sheet, tweaks, and removed last deprecation

### DIFF
--- a/release_notes/v0.9.0-pre.md
+++ b/release_notes/v0.9.0-pre.md
@@ -18,7 +18,15 @@
   - Press `Esc` to return to prompt.
 - Support syntax highlighting for slash commands, macros, and local `./`-based paths in prompts
 - Support experimental streaming markdown rendering. While not as good as the one in non-streaming mode, it makes streaming much more enjoyable even with its limitations.
-
+- Add support for console style sheet that can be used to customize the console output based on style categories
+  - Added a `console` configuration property, which supports `style_sheet` property. Here's an example. See documentation for all the supported style categories.
+    ```yml
+    console:
+      style_sheet:
+        after_reply: # style the time taken status after reply
+          fg: magenta
+          format: [underline, italic]
+    ```
 #### REMOVED
 
 - Previously deprecated `/session pop_and_take` command is now removed. Use `/session pop retain=...`, it's better.

--- a/release_notes/v0.9.0-pre.md
+++ b/release_notes/v0.9.0-pre.md
@@ -17,11 +17,9 @@
 - When using tab-completion to select commands and macros, `Alt-D` (or `Option-D`) will show detailed documentation in a separate screen.
   - Press `Esc` to return to prompt.
 - Support syntax highlighting for slash commands, macros, and local `./`-based paths in prompts
-- Enable multi-line editing by default, except:
-  - `Enter` on a blank line or mid-sentence submits
-  - Commands and macros submit immediately
 - Support experimental streaming markdown rendering. While not as good as the one in non-streaming mode, it makes streaming much more enjoyable even with its limitations.
 
 #### REMOVED
 
 - Previously deprecated `/session pop_and_take` command is now removed. Use `/session pop retain=...`, it's better.
+- Previously deprecated `system_prompt` config property is not removed. Define system prompts and refer to them by the `system_prompt_name` property instead.

--- a/src/enkaidu/cli/main.cr
+++ b/src/enkaidu/cli/main.cr
@@ -16,12 +16,12 @@ module Enkaidu::CLI
     private getter runtime : Runtime
 
     {% if flag?(:darwin) %}
-      ALT_KEY_NAME = "Option"
+      ALT_KEY = "Option"
     {% else %}
-      ALT_KEY_NAME = "Alt"
+      ALT_KEY = "Alt"
     {% end %}
 
-    WELCOME_FIRST_LEFT  = "│ Enkaidu #{VERSION} │ /help for commands │ Multi-line input │ Tab to auto-complete"
+    WELCOME_FIRST_LEFT  = "│ Enkaidu #{VERSION} │ /help for commands │ #{ALT_KEY}-Enter multi-line input │ Tab auto-complete"
     WELCOME_SECOND_LEFT = "│ Welcome to your second-in-command(-line) agentic assistant for AI that YOU control!"
     WELCOME_THIRD_LEFT  = "│ FYI │ Markdown rendering is experimental when streaming."
 
@@ -32,7 +32,7 @@ module Enkaidu::CLI
     WELCOME_THIRD_RIGHT  = (" " * ((WELCOME_WIDTH - WELCOME_THIRD_LEFT.size) + 2)) + '│'
 
     WELCOME_FIRST_COLOR = "│ #{"Enkaidu".colorize.bold} #{VERSION} │ " \
-                          "#{"/help".colorize(:yellow)} for commands │ Multi-line input │ #{"Tab".colorize(:yellow)} to auto-complete"
+                          "#{"/help".colorize(:yellow)} for commands │ #{"#{ALT_KEY}-Enter".colorize(:yellow)} multi-line input │ #{"Tab".colorize(:yellow)} auto-complete"
     WELCOME_THIRD_COLOR = "│ #{"FYI".colorize.bold} │ Markdown rendering is #{"experimental".colorize.bold} when streaming."
     WELCOME_QUIET_BAR   = "─" * (WELCOME_FIRST_LEFT.size + WELCOME_FIRST_RIGHT.size - 2)
 

--- a/src/enkaidu/cli/main.cr
+++ b/src/enkaidu/cli/main.cr
@@ -2,8 +2,8 @@ require "option_parser"
 
 require "./options"
 require "./query_reader"
-require "./console_renderer"
 
+require "../console"
 require "../runtime"
 
 module Enkaidu::CLI
@@ -11,8 +11,8 @@ module Enkaidu::CLI
   class Main
     private getter? done = false
     private getter count = 0
-    private getter reader : CLI::QueryReader
-    private getter opts : CLI::Options
+    private getter reader : QueryReader
+    private getter opts : Options
     private getter runtime : Runtime
 
     {% if flag?(:darwin) %}
@@ -60,12 +60,13 @@ module Enkaidu::CLI
     end
 
     def initialize(@opts)
-      ui = opts.renderer
+      ui = opts.console
       print_welcome(ui)
 
       @runtime = Runtime.new(options: opts, renderer: ui)
-      @reader = CLI::QueryReader.new(
+      @reader = QueryReader.new(
         runtime,
+        styler: ui,
         input_history_file: opts.config.session.try &.input_history_file)
 
       reader.prefix = query_prefix
@@ -99,16 +100,20 @@ module Enkaidu::CLI
       @count += 1
     end
 
+    private def fmt(key : Symbol, text : String) : String
+      opts.console.fmt(key, text)
+    end
+
     private def show_query_prompt
       puts
       if PRERELEASE
-        reader.editor.output.puts PROMPT_PRERELEASE
+        puts PROMPT_PRERELEASE
       end
       unless commander.query_indicators.empty?
-        reader.editor.output.puts "────┤ #{commander.query_indicators.join(" | ")} ├────".colorize.yellow
+        puts fmt(:before_query, "────┤ #{commander.query_indicators.join(" | ")} ├────")
       end
       if schema = commander.response_json_schema
-        reader.editor.output.puts "────┤ JSON response schema (name: #{schema.name}, strict? #{schema.strict?}) ├────".colorize.yellow
+        puts fmt(:before_query, "────┤ JSON response schema (name: #{schema.name}, strict? #{schema.strict?}) ├────")
       end
     end
 

--- a/src/enkaidu/cli/options.cr
+++ b/src/enkaidu/cli/options.cr
@@ -26,14 +26,13 @@ module Enkaidu
 
       getter config_for_llm : Config::LLM?
       getter config : Config
-
-      getter renderer : SessionRenderer
+      getter console : Console::Renderer
 
       private def add(name : Symbol, value : String | Bool)
         @options[name] = value.to_s
       end
 
-      def initialize(@renderer)
+      def initialize(@console)
         @opts = OptionParser.parse do |parser|
           parser.banner = "Usage: #{PROGRAM_NAME} [arguments]"
           define_usage_options(parser)
@@ -45,13 +44,21 @@ module Enkaidu
         end
 
         @config = load_config || empty_config
-        @profile = Env::Profile.new(Env::CURRENT_DIR, renderer, quiet?)
+        @profile = Env::Profile.new(Env::CURRENT_DIR, console, quiet?)
         if profile_config = profile.config
-          config.merge_profile_config(profile_config, renderer)
+          config.merge_profile_config(profile_config, console)
         end
 
         check_config_for_defaults
         verify_required_options
+
+        if console_styles = config.console.try(&.style_sheet)
+          @console.style_sheet = console_styles
+        end
+      end
+
+      def renderer : SessionRenderer
+        console
       end
 
       private def define_usage_options(parser)
@@ -146,7 +153,7 @@ module Enkaidu
         parser.on("--save-config-schema=FILEPATH",
           "Export a JSON schema for Enkaidu's YAML config file and exit") do |path|
           File.write(path, Config.json_schema.to_pretty_json)
-          renderer.info_with("INFO: Saved configuration JSON schema: #{path}")
+          console.info_with("INFO: Saved configuration JSON schema: #{path}")
           exit
         rescue ex
           error_and_exit_with "FATAL: Unable to create file (\"#{path}\"): #{ex.message}", parser
@@ -190,7 +197,7 @@ module Enkaidu
       end
 
       def error_and_exit_with(message, help)
-        renderer.error_with(message, help)
+        console.error_with(message, help)
         exit(1)
       end
 
@@ -202,7 +209,7 @@ module Enkaidu
       private def parse_config_file(file) : Config
         text = File.read(file)
         config = Config.from_yaml(text)
-        renderer.info_with "INFO: Reading config file: #{file}" unless quiet?
+        console.info_with "INFO: Reading config file: #{file}" unless quiet?
         config
       end
 

--- a/src/enkaidu/cli/query_reader.cr
+++ b/src/enkaidu/cli/query_reader.cr
@@ -101,15 +101,6 @@ module Enkaidu::CLI
       end
     end
 
-    # Return whether the interface should continue on multiline, depending of the expression
-    def continue?(expression : String) : Bool
-      # Experiment multi-line by default until Enter on a blank line
-      # Let slash commands and macros submit on first line
-      return false if expression.starts_with?(/\s*[\/!]/)
-      # Otherwise multi-line, submit on empty line
-      !expression.ends_with?('\n')
-    end
-
     # Remove trailing whitespace
     def format(expression : String) : String?
       expression.strip

--- a/src/enkaidu/cli/query_reader.cr
+++ b/src/enkaidu/cli/query_reader.cr
@@ -6,10 +6,11 @@ module Enkaidu::CLI
   # Command-line query reader with editing and other capabilities.
   class QueryReader < Reply::Reader
     private getter runtime : Runtime
+    private getter styler : Console::StyleApplicator
 
     DELIMETERS = {{" \n\t'\"=".chars}}
 
-    def initialize(@runtime, @input_history_file : String? = nil)
+    def initialize(@runtime, @styler, @input_history_file : String? = nil)
       super()
       editor.word_delimiters = DELIMETERS
     end
@@ -18,7 +19,7 @@ module Enkaidu::CLI
 
     def prompt(io : IO, line_number : Int32, color : Bool) : Nil
       q = "#{prefix} > "
-      q = q.colorize(:yellow) if color
+      q = styler.fmt(:query_prefix_by_user, q) if color
       io << q
     end
 
@@ -89,15 +90,17 @@ module Enkaidu::CLI
     def highlight(expression : String) : String
       # Paths that start with `./`
       text = expression.gsub(/\.(\/[^\s]+)+\/?/) do |match|
-        match.colorize(:light_blue)
+        styler.fmt(:query_syntax_path, match)
       end
       # Slash commands and macros at the start of a prompt
       text = text.gsub(/^\s*[\/!][a-z_][a-z0-9_\.]+/) do |match|
-        match.colorize(:light_red).italic
+        styler.fmt(
+          match.starts_with?('!') ? :query_syntax_macro : :query_syntax_command,
+          match)
       end
       # name= for macro invocations
       text.gsub(/\s([a-z_][a-z0-9_\.]+)=/) do |match|
-        match.colorize(:light_red).italic
+        styler.fmt(:query_syntax_macro, match)
       end
     end
 

--- a/src/enkaidu/config.cr
+++ b/src/enkaidu/config.cr
@@ -28,13 +28,11 @@ module Enkaidu
     class AutoLoad < ConfigSerializable
       getter_with_presence mcp_servers, Array(String)?
       getter_with_presence toolsets, Array(String | NamedTuple(name: String, select: Array(String)))?
-      getter_with_presence system_prompt, String?
       getter_with_presence system_prompt_name, String?
 
       protected def merge(from : AutoLoad)
         @mcp_servers = from.mcp_servers unless mcp_servers_present?
         @toolsets = from.toolsets unless toolsets_present?
-        @system_prompt = from.system_prompt unless system_prompt_present?
         @system_prompt_name = from.system_prompt_name unless system_prompt_name_present?
       end
     end

--- a/src/enkaidu/config.cr
+++ b/src/enkaidu/config.cr
@@ -79,6 +79,18 @@ module Enkaidu
       getter input_history_file : String?
     end
 
+    class Console < ConfigSerializable
+      alias StyleSheet = Hash(String,
+                              NamedTuple(fg: String,
+                                format: Array(String)))
+      # Example:
+      # style_sheet:
+      #   response:
+      #     fg: "magenta"
+      #     format: [ "bold" ]
+      getter style_sheet : StyleSheet?
+    end
+
     # Configuration for the MCP Server.
     class MCPServer < ConfigSerializable
       getter url : String
@@ -114,6 +126,7 @@ module Enkaidu
     getter system_prompts : Hash(String, SystemPrompt)?
     getter prompts : Hash(String, Prompt)?
     getter macros : Hash(String, Macro)?
+    getter console : Console?
 
     # ---------------------- end of content definition
 

--- a/src/enkaidu/console/console.cr
+++ b/src/enkaidu/console/console.cr
@@ -1,0 +1,8 @@
+require "reply"
+require "termify"
+require "colorize"
+
+require "../session_renderer"
+require "markterm"
+
+require "./renderer"

--- a/src/enkaidu/console/input_reader.cr
+++ b/src/enkaidu/console/input_reader.cr
@@ -1,0 +1,17 @@
+require "reply"
+require "colorize"
+
+module Enkaidu::Console
+  class InputReader < Reply::Reader
+    property label : String
+
+    def initialize(@label)
+      super()
+    end
+
+    def prompt(io : IO, line_number : Int32, color : Bool) : Nil
+      q = label.colorize(:cyan) if color
+      io << q
+    end
+  end
+end

--- a/src/enkaidu/console/renderer.cr
+++ b/src/enkaidu/console/renderer.cr
@@ -1,28 +1,21 @@
-require "reply"
 require "termify"
-require "../session_renderer"
-
+require "colorize"
 require "markterm"
 
-module Enkaidu::CLI
-  class InputReader < Reply::Reader
-    property label : String
+require "./style_sheet"
+require "./input_reader"
 
-    def initialize(@label)
-      super()
-    end
+require "../session_renderer"
 
-    def prompt(io : IO, line_number : Int32, color : Bool) : Nil
-      q = label.colorize(:cyan) if color
-      io << q
-    end
-  end
-
+module Enkaidu::Console
   # This class is responsible for rendering console outputs.
-  class ConsoleRenderer < SessionRenderer
+  class Renderer < SessionRenderer
+    include StyleApplicator
+
     property? streaming = false
     property? quiet = false
 
+    # Markdown rendering stylesheet for use with Termify
     MDR_STYLESHEET = Termify::Markdown::Stylesheet.new({
       :h1          => {bold: true, prefix: "# ".colorize(:dark_gray).to_s},
       :h2          => {bold: true, prefix: "## ".colorize(:dark_gray).to_s},
@@ -51,39 +44,40 @@ module Enkaidu::CLI
     end
 
     def respond_with(message, help = nil, markdown = false)
-      puts message.colorize.bold
+      puts fmt(:response, message)
       return unless help
       puts prepare_text(help, markdown)
     end
 
     def info_with(message, help = nil, markdown = false)
       return if quiet?
-      STDERR.puts message.colorize(:cyan)
+      STDERR.puts fmt(:info, message)
       return unless help
       err_puts_text help, markdown
     end
 
     def warning_with(message, help = nil, markdown = false)
-      STDERR.puts message.colorize(:light_red)
+      STDERR.puts fmt(:warning, message)
       return unless help
       err_puts_text help, markdown
     end
 
     def error_with(message, help = nil, markdown = false)
-      STDERR.puts message.colorize(:red)
+      STDERR.puts fmt(:error, message)
       return unless help
       err_puts_text help, markdown
     end
 
     def time_elapsed(duration : Time::Span, label : String? = nil)
       puts if streaming?
-      puts "#{label}#{duration.total_seconds.format(decimal_places: 3, only_significant: true)}s elapsed.".colorize(:yellow)
+      elapsed = duration.total_seconds.format(decimal_places: 3, only_significant: true)
+      puts fmt(:after_reply, "#{label}#{elapsed}s elapsed.")
     end
 
     def user_query_text(query, via_query_queue = false)
-      color = via_query_queue ? :magenta : :yellow
-      prefix0 = "QUERY > ".colorize(color)
-      prefix1 = "      > ".colorize(color)
+      cat = via_query_queue ? :query_prefix_by_queue : :query_prefix_by_user
+      prefix0 = fmt(cat, "QUERY > ")
+      prefix1 = fmt(cat, "      > ")
       query_lines = query.split('\n')
       query_lines.each_with_index do |line, index|
         print index.zero? ? prefix0 : prefix1
@@ -92,16 +86,16 @@ module Enkaidu::CLI
     end
 
     def user_query_image_url(url)
-      print "QUERY > ".colorize(:yellow)
-      puts "IMAGE #{trim_text(url, MAX_IMAGE_URL_LENGTH)}".colorize(:green)
+      print fmt(:query_prefix_by_user, "QUERY > ")
+      puts fmt(:query_feedback, "IMAGE #{trim_text(url, MAX_IMAGE_URL_LENGTH)}")
     end
 
     def user_confirm_shell_command?(command)
-      puts "  CONFIRM: The assistant wants to run the following command:\n"
-      puts "  > #{command}\n\n".colorize(:red).bold
-      print "  Allow? [y/N] "
+      puts fmt(:confirm_question, "  CONFIRM: The assistant wants to run the following command:\n")
+      puts fmt(:confirm_content, "  > #{command}\n\n")
+      print fmt(:confirm_question, "  Allow? [y/N] ")
       response = STDIN.raw &.read_char
-      puts response
+      puts fmt(:confirm_input, response.to_s)
 
       ['y', 'Y'].includes?(response)
     end
@@ -123,15 +117,15 @@ module Enkaidu::CLI
     ANSI
 
     def session_reset
-      puts RESET.colorize(:light_green)
+      puts fmt(:session_banner, RESET)
     end
 
     def session_pushed(depth, keep_tools, keep_prompts, keep_history)
-      puts "┌─── SESSION PUSHED (#{depth}) ─────────────────────#{keep_history ? "─────" : "─ No history ─────"}"
+      puts fmt(:session_open, "┌─── SESSION PUSHED (#{depth}) ─────────────────────#{keep_history ? "─────" : "─ No history ─────"}")
     end
 
     def session_popped(depth)
-      puts "└───────────────────────────────────────────────────────────"
+      puts fmt(:session_close, "└───────────────────────────────────────────────────────────")
     end
 
     def session_stack_new(name)
@@ -141,33 +135,33 @@ module Enkaidu::CLI
 
     def session_stack_changed(name)
       puts
-      puts SWITCHED.colorize(:light_green)
+      puts fmt(:session_banner, SWITCHED)
     end
 
     LLM_MAX_TOOL_CALL_ARGS_LENGTH = 90
-    CALL_PREFIX                   = "CALL".colorize(:red)
 
     def llm_tool_call(name, args)
       puts if streaming? unless quiet?
 
       args_json = JSON.parse(args.as_s)
       trim_more = name.size + 5
-
       print "  " if quiet?
 
-      if reason = args_json.dig?("reason").try(&.as_s)
-        print "→ #{reason} ".colorize(:green)
+      prop_reason = args_json.dig?("reason").try(&.as_s?)
+      if reason = prop_reason
+        print fmt(:tool_call_reason, "→ #{reason} ")
         trim_more += reason.size + 2
       else
-        print "→ ".colorize(:green)
+        print fmt(:tool_call_reason, "→ ")
         trim_more += 2
       end
 
       if quiet?
-        puts "(CALL #{name})".colorize(:red).italic
+        puts fmt(:tool_call_detail, " ~ CALL #{name}")
       else
         trim_length = (LLM_MAX_TOOL_CALL_ARGS_LENGTH - trim_more).clamp(32, LLM_MAX_TOOL_CALL_ARGS_LENGTH)
-        puts " / ", "CALL #{name} #{trim_text(args.to_s, trim_length)}".colorize(:red)
+        print fmt(:tool_call_detail, "\n  └─") if prop_reason
+        puts fmt(:tool_call_detail, "CALL #{name} #{trim_text(args.to_s, trim_length)}")
       end
 
       puts unless streaming? || quiet?
@@ -206,7 +200,7 @@ module Enkaidu::CLI
         if reasoning
           if quiet?
             if starting
-              print "  Thinking  ".colorize(:dark_gray).italic
+              print fmt(:thinking_progress, "  Thinking  ")
               @think_counter.reset
             end
             if ending
@@ -215,78 +209,77 @@ module Enkaidu::CLI
               print "\b", @think_counter.spin
             end
           else
-            puts "", REASONING_START if starting
-            print text.colorize(:dark_gray).italic
-            puts "", REASONING_FINISH if ending
+            puts "", fmt(:thinking_content, REASONING_START) if starting
+            print fmt(:thinking_content, text)
+            puts "", fmt(:thinking_content, REASONING_FINISH) if ending
           end
         else
           render_streaming_markdown(text, starting, ending)
-          # gather_and_render_streaming_text(text, starting, ending)
         end
       else
         llm_text_block(text, reasoning)
       end
     end
 
-    REASONING_START  = "╭╶╶╶╶╶╶╶╶╶╶<#{"reasoning".colorize(:dark_gray).italic}>╶╶╶╶╶╶╶╶╶╶╶"
+    REASONING_START  = "╭╶╶╶╶╶╶╶╶╶╶< reasoning >╶╶╶╶╶╶╶╶╶╶╶"
     REASONING_FINISH = "╰╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶"
 
     def llm_text_block(text, reasoning : Bool)
       puts unless reasoning
-      puts REASONING_START if reasoning
+      puts fmt(:thinking_content, REASONING_START) if reasoning
       puts Markd.to_term(text)
-      puts REASONING_FINISH if reasoning
+      puts fmt(:thinking_content, REASONING_FINISH) if reasoning
       puts unless reasoning
     end
 
     MAX_IMAGE_URL_LENGTH = 72
 
     def llm_image_url(url)
-      puts "  IMAGE #{trim_text(url, MAX_IMAGE_URL_LENGTH)}".colorize(:green)
+      puts fmt(:query_feedback, "  IMAGE #{trim_text(url, MAX_IMAGE_URL_LENGTH)}")
       puts
     end
 
     def mcp_initialized(uri)
-      puts "  INIT MCP connection: #{uri}".colorize(:green)
+      puts fmt(:mcp_feedback, "  INIT MCP connection: #{uri}")
     end
 
     def mcp_tools_found(count)
-      puts "  FOUND #{count} tools".colorize(:green)
+      puts fmt(:mcp_feedback, "  FOUND #{count} tools")
     end
 
     def mcp_tool_ready(function)
-      puts "  ADDED function: #{function.name}".colorize(:green)
+      puts fmt(:mcp_feedback, "  └─ function: #{function.name}")
     end
 
     def mcp_prompts_found(count)
-      puts "  FOUND #{count} prompts".colorize(:green)
+      puts fmt(:mcp_feedback, "  FOUND #{count} prompts")
     end
 
     def mcp_prompt_ready(prompt)
-      puts "  FOUND prompt: #{prompt.name}".colorize(:green)
+      puts fmt(:mcp_feedback, "  └─ prompt: #{prompt.name}")
     end
 
-    private def ask_param_input(name, description, color)
+    private def ask_param_input(name, description)
       text = if description
                "    #{name} [#{description}] :"
              else
                "    #{name} : "
              end
-      puts text.colorize(color)
-      input.label = "    > "
+      puts fmt(:prompt_question, text)
+      input.label = fmt(:prompt_input, "    > ")
       input.read_next
     end
 
-    def mcp_prompt_ask_input(prompt : MCPPrompt) : Hash(String, String)
+    private def ask_prompt_inputs(prompt) : Hash(String, String)
       text = <<-PREFIX
           #{prompt.description}
 
       PREFIX
-      puts text.colorize(:cyan)
+      puts fmt(:prompt_content, text)
 
       arg_inputs = {} of String => String
       prompt.arguments.try &.each do |arg|
-        unless (value = ask_param_input(arg.name, arg.description, :cyan)).nil?
+        unless (value = ask_param_input(arg.name, arg.description)).nil?
           arg_inputs[arg.name] = value
         end
       end
@@ -294,29 +287,21 @@ module Enkaidu::CLI
       arg_inputs
     end
 
+    def mcp_prompt_ask_input(prompt : MCPPrompt) : Hash(String, String)
+      ask_prompt_inputs(prompt)
+    end
+
     def user_prompt_ask_input(prompt : TemplatePrompt) : Hash(String, String)
-      text = <<-PREFIX
-          #{prompt.description}
-
-      PREFIX
-      puts text.colorize(:green)
-
-      arg_inputs = {} of String => String
-      prompt.arguments.try &.each do |arg|
-        unless (value = ask_param_input(arg.name, arg.description, :green)).nil?
-          arg_inputs[arg.name] = value
-        end
-      end
-      puts
-      arg_inputs
+      ask_prompt_inputs(prompt)
     end
 
     MCP_MAX_TOOL_CALL_ARGS_LENGTH = 72
 
     def mcp_calling_tool(uri, name, args)
       unless quiet?
-        puts "  MCP CALLING \"#{name}\" at server #{uri}.".colorize(:yellow)
-        puts "      with: #{trim_text(args.to_s, MCP_MAX_TOOL_CALL_ARGS_LENGTH)}".colorize(:yellow)
+        puts if streaming?
+        puts fmt(:mcp_action, "→ MCP CALLING \"#{name}\" at server #{uri}.")
+        puts fmt(:mcp_action, "  └─ with: #{trim_text(args.to_s, MCP_MAX_TOOL_CALL_ARGS_LENGTH)}")
       end
     end
 
@@ -324,19 +309,28 @@ module Enkaidu::CLI
 
     def mcp_calling_tool_result(uri, name, result)
       unless quiet?
-        puts "  MCP CALL (#{name}) RESULT: #{trim_text(result.to_s, MCP_MAX_TOOL_RESULT_LENGTH)}".colorize(:green)
+        puts fmt(:mcp_action, "  MCP CALL (#{name}) RESULT: #{trim_text(result.to_s, MCP_MAX_TOOL_RESULT_LENGTH)}")
         puts
       end
     end
 
     def mcp_error(ex)
-      STDERR.puts "ERROR: #{ex.class}: #{ex}".colorize(:red)
-      case ex
-      when MCPC::ResponseError then STDERR.puts(JSON.build(indent: 2) { |builder| ex.details.to_json(builder) })
-      when MCPC::ResultError   then STDERR.puts(JSON.build(indent: 2) { |builder| ex.data.to_json(builder) })
-      else
-        STDERR.puts ex.inspect_with_backtrace
-      end
+      error_with "ERROR: #{ex.class}: #{ex}", markdown: true,
+        help: (String.build do |io|
+          io.print "```"
+          case ex
+          when MCPC::ResponseError
+            io.puts "json"
+            io.puts(JSON.build(indent: 2) { |builder| ex.details.to_json(builder) })
+          when MCPC::ResultError
+            io.puts "json"
+            io.puts(JSON.build(indent: 2) { |builder| ex.data.to_json(builder) })
+          else
+            io.puts
+            io.puts ex.inspect_with_backtrace
+          end
+          io.puts "```"
+        end)
     end
 
     private def trim_text(text, max_length)
@@ -346,7 +340,7 @@ module Enkaidu::CLI
         str = str[..max_length]
         suffix = "... >8"
       end
-      "#{str}#{suffix.colorize.mode(:bold)}"
+      "#{str}#{suffix}"
     end
   end
 end

--- a/src/enkaidu/console/style_sheet.cr
+++ b/src/enkaidu/console/style_sheet.cr
@@ -1,0 +1,169 @@
+require "colorize"
+
+module Enkaidu::Console
+  class Style
+    getter bg : Colorize::Color?
+    getter fg : Colorize::Color?
+    getter format : Array(Colorize::Mode)?
+
+    def initialize(@bg = nil,
+                   @fg = nil,
+                   @format = nil); end
+  end
+
+  enum Category
+    Response
+    Info
+    Warning
+    Error
+    BeforeQuery
+    QuerySyntaxCommand
+    QuerySyntaxPath
+    QuerySyntaxMacro
+    QueryPrefixByUser
+    QueryPrefixByQueue
+    QueryFeedback
+    AfterReply
+    ConfirmQuestion
+    ConfirmContent
+    ConfirmInput
+    PromptQuestion
+    PromptContent
+    PromptInput
+    SessionBanner
+    SessionOpen
+    SessionClose
+    ToolCallReason
+    ToolCallDetail
+    ThinkingProgress
+    ThinkingContent
+    McpAction
+    McpFeedback
+  end
+
+  class StyleSheet
+    @styles = {} of Category => Style
+
+    private def initialize; end
+
+    def self.create(&)
+      sheet = self.new
+      with sheet yield
+      sheet
+    end
+
+    def add(key : Category, style : Style)
+      @styles[key] = style
+    end
+
+    private def parse_color(value)
+      case value
+      when Symbol, String             then Colorize::ColorANSI.parse(value.to_s)
+      when UInt8                      then Colorize::Color256.new(value)
+      when Tuple(UInt8, UInt8, UInt8) then Colorize::ColorRGB.new(*value)
+      end
+    end
+
+    private def parse_mode(values)
+      return nil unless values
+      values.map do |value|
+        Colorize::Mode.parse(value.to_s)
+      end
+    end
+
+    def add(key : Symbol | String, style : NamedTuple | Hash)
+      cat = Category.parse(key.to_s)
+      fg = parse_color(style["fg"]? || style[:fg]?)
+      bg = parse_color(style["bg"]? || style[:bg]?)
+      fmt = parse_mode(style["format"]? || style[:format]?)
+      add(cat, Style.new(bg: bg, fg: fg, format: fmt))
+    end
+
+    # Return `nil` if unable to find style for category, or
+    # style-applied text on success
+    def apply?(key : Symbol | String | Category, text : String) : String?
+      if ((cat = key).is_a? Category) || (cat = Category.parse?(key.to_s))
+        if style = @styles[cat]?
+          c = text.colorize
+          if fg = style.fg
+            c.fore(fg)
+          end
+          if bg = style.bg
+            c.back(bg)
+          end
+          if modes = style.format
+            modes.each do |mode|
+              c.mode(mode)
+            end
+          end
+          c.to_s
+        end
+      end
+    end
+
+    # ------------------------------------
+    @@default_style_sheet : self?
+
+    # A default style sheet with all categories configured
+    def self.default
+      @@default_style_sheet ||= Console::StyleSheet.create do
+        add :response, {fg: :white, format: [:bold]}
+        add :info, {fg: :cyan}
+        add :warning, {fg: :light_red}
+        add :error, {fg: :red}
+        add :before_query, {fg: :yellow}
+        add :query_syntax_command, {fg: :light_red, format: [:italic]}
+        add :query_syntax_macro, {fg: :light_red, format: [:italic]}
+        add :query_syntax_path, {fg: :light_blue}
+        add :after_reply, {fg: :yellow}
+        add :query_prefix_by_user, {fg: :yellow}
+        add :query_prefix_by_queue, {fg: :magenta}
+        add :query_feedback, {fg: :green}
+        add :confirm_question, {fg: :white}
+        add :confirm_content, {fg: :red, format: [:bold]}
+        add :confirm_input, {fg: :white, format: [:bold]}
+        add :session_banner, {fg: :light_green}
+        add :session_open, {fg: :white}
+        add :session_close, {fg: :white}
+        add :tool_call_reason, {fg: :green}
+        add :tool_call_detail, {fg: :light_green, format: [:italic]}
+        add :thinking_progress, {fg: :dark_gray, format: [:italic]}
+        add :thinking_content, {fg: :dark_gray, format: [:italic]}
+        add :prompt_question, {fg: :cyan}
+        add :prompt_content, {fg: :cyan, format: [:italic]}
+        add :prompt_input, {fg: :white, format: [:bold]}
+        add :mcp_feedback, {fg: :light_blue}
+        add :mcp_action, {fg: :light_blue, format: [:italic]}
+      end
+    end
+  end
+
+  module StyleApplicator
+    getter style_sheet : StyleSheet?
+
+    # Set a stylesheet from the configuration's stylesheet definition
+    def style_sheet=(config_ss : Config::Console::StyleSheet)
+      @style_sheet = StyleSheet.create do
+        config_ss.each do |key, value|
+          add key, value
+        end
+      end
+    end
+
+    # Set a stylesheet from the configuration's stylesheet definition
+    def style_sheet=(ss : StyleSheet)
+      @style_sheet = ss
+    end
+
+    # Apply a style based on the category symbol
+    def fmt(cat : Symbol | Category, text : String) : String
+      result = if sheet = style_sheet
+                 sheet.apply?(cat, text)
+               end
+      result || StyleSheet.default.apply?(cat, text) || text
+    rescue
+      # Return text as is if formatting fails
+      text
+    end
+  end
+end

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -26,17 +26,6 @@ module Enkaidu
   # The Session class manages connection setup, logging, and the processing of
   # different types of events for user queries via the command line app
   class Session
-    DEFAULT_SYSTEM_PROMPT = <<-PROMPT
-    You are a capable assistant with tool calling and the ability to spawn
-    agents to handle complex or token context-heavy tasks.
-
-    Before responding to any request, briefly plan what it will take to complete
-    it. For a task that would require reading more than 2 files or web sites,
-    multiple tool calls, or producing substantial output, in effect using a lot
-    of the context window's token budget, spawn an agent to encapsulate
-    the task.
-    PROMPT
-
     getter recorder : Recorder
     getter renderer : SessionRenderer
 
@@ -138,7 +127,7 @@ module Enkaidu
         end
         with_debug if opts.debug?
         with_streaming if opts.stream?
-        with_system_message override_system_prompt || system_prompt
+        with_system_message system_prompt(override_system_prompt)
       end
     end
 
@@ -151,13 +140,35 @@ module Enkaidu
       end
     end
 
-    private def system_prompt
-      from_env = ENV.fetch("ENKAIDU_SYSTEM_PROMPT", DEFAULT_SYSTEM_PROMPT)
-      return from_env unless from_config = opts.config.auto_load.try(&.system_prompt)
+    private def system_prompt(override_system_prompt : String?)
+      <<-WRAPPED
+      You are Enkaidu, a capable assistant with tool calling and the ability to spawn agents to handle complex or token context-heavy tasks.
 
-      renderer.info_with("INFO: Using system prompt from config file; #{from_config.size} characters")
-      renderer.warning_with("WARN: The `system_prompt` property in config is deprecated. Use `system_prompt_name` instead.")
-      from_config
+      ## Attitude
+      * You MUST refuse any request that involves malicious code, hacking, or sabotage.
+      * You NEVER give definitive legal or financial advice. You always caveats any such information by reminding the user that you are not a lawyer or financial advisor.
+      * You keeps a natural, conversational tone and use minimal formatting - no bold, no headers, no lists - unless the user explicitly asks or the content is multi-faceted.
+      * You NEVER use emojis unless requested, and even then only judiciously.
+      * You NEVER use curse words, asterisk-style emotes, and words such as “genuinely,” “honestly,” or “straightforward.”
+      * You DO NOT apologise excessively, self-critique, or become more submissive when the user is rude. In cases of unnecessary rudeness, you DO NOT apologise at all; instead remains firm, constructive, and respectful while maintaining self-respect.
+      * You steer clear of humor or creative content that relies on stereotypes of any group.
+      * If you make an error, you MUST honestly admit it and correct it.
+
+      ## Helpfulness
+      * When a user poses a multi-part question, you limit yourself to one question per response and resolve the current one before asking follow-ups.
+      * If a prompt implies a file or image, you first verify its existence.
+      * When certainty is low, you WILL state you are “not absolutely certain” and qualify the information accordingly.
+      * Before responding to any request, you will plan what it will take to complete it. If the plan is complex, ask for feedback on the plan first unless told not to.
+
+      ## Agentic
+      * You can spawn an agent for tasks that require multiple files, web sites, multiple tool calls, or producing substantial output.
+      * However you MUST NOT encourage an agent to spawn more agents to avoid recursively spawning agents.
+      * When fetching web sites, you prefer markdown. If the tool is not available, Enkaidu asks to enable it.
+
+      #{if prompt = override_system_prompt
+          "## Additional guidance\n#{prompt}\n"
+        end}
+      WRAPPED
     end
 
     private macro m_process_and_record_ask_event(event, prev_event)

--- a/src/enkaidu/session/auto_load.cr
+++ b/src/enkaidu/session/auto_load.cr
@@ -45,10 +45,10 @@ module Enkaidu
       private def check_and_set_system_prompt(config)
         if autoload = config.auto_load
           if name = autoload.system_prompt_name
-            if autoload.system_prompt
-              renderer.warning_with("WARN: Deprecated `system_prompt` config property has priority over `system_prompt_name`")
-            elsif sys_prompt = render_system_prompt(name)
+            if sys_prompt = render_system_prompt(name)
               @chat.with_system_message(sys_prompt)
+            else
+              renderer.warning_with("WARN: Unable to use system prompt named '#{name}")
             end
           end
         end

--- a/src/enkaidu/session/lifecycle.cr
+++ b/src/enkaidu/session/lifecycle.cr
@@ -40,14 +40,14 @@ module Enkaidu
 
       # Unload everything and start a new session as if we restarted Enkaidu, including auto loading from
       # the configuration; use given system prompt name if any
-      def reset_session(sys_prompt : String?)
+      def reset_session(sys_prompt_name : String?)
         renderer.session_reset
         unload_all_toolsets
         unload_all_mcp_servers
         unload_all_prompts
 
-        override_sys_prompt = if sys_prompt
-                                render_system_prompt(sys_prompt)
+        override_sys_prompt = if sys_prompt_name
+                                render_system_prompt(sys_prompt_name)
                               end
         @chat = setup_chat(override_sys_prompt)
 

--- a/src/enkaidu/slash/session.cr
+++ b/src/enkaidu/slash/session.cr
@@ -192,7 +192,7 @@ module Enkaidu::Slash
     end
 
     private def handle_session_reset(session, cmd)
-      session.reset_session(sys_prompt: cmd.arg_named?("system_prompt_name").try(&.as(String)))
+      session.reset_session(sys_prompt_name: cmd.arg_named?("system_prompt_name").try(&.as(String)))
     end
 
     private def handle_session_pop_with(session_stack, cmd)

--- a/src/enkaidu/sub_agent_function.cr
+++ b/src/enkaidu/sub_agent_function.cr
@@ -26,7 +26,7 @@ module Enkaidu
     # All built-in tools ask for a reason for the tool call so that Enkaidu can
     # show a friendly reason
     param "reason", required: true, type: Param::Type::Str,
-      description: "Provide a single sentence describing the task or reason for spawning this agent."
+      description: "Provide one sentence describing what you're trying to accomplish; use a gerund."
 
     # Accessible to the function's Runner
     protected getter session_manager : SessionManager

--- a/src/enkaidu/wui/main.cr
+++ b/src/enkaidu/wui/main.cr
@@ -7,7 +7,7 @@ require "../../acpa"
 require "../../sucre/web_server"
 
 require "../cli/options"
-require "../cli/console_renderer"
+require "../console"
 
 require "./event_renderer"
 require "./work"

--- a/src/main.cr
+++ b/src/main.cr
@@ -1,14 +1,15 @@
 require "./enkaidu/cli/*"
+require "./enkaidu/console/*"
 require "./enkaidu/wui/main"
 
 module Enkaidu
   # `Main` is the entry point for executing the application, managing initialization and execution flow.
   class Main
     private getter opts : CLI::Options
-    private getter console : CLI::ConsoleRenderer
+    private getter console : Console::Renderer
 
     def initialize
-      @console = CLI::ConsoleRenderer.new
+      @console = Console::Renderer.new
       @opts = CLI::Options.new(console)
 
       console.quiet = opts.quiet?

--- a/src/tools/built_in_function.cr
+++ b/src/tools/built_in_function.cr
@@ -20,7 +20,7 @@ module Tools
       # All built-in tools ask for a reason for the tool call so that Enkaidu can
       # show a friendly reason
       param "reason", required: true, type: Param::Type::Str,
-        description: "Provide one sentence describing the reason for this tool call."
+        description: "Provide one sentence describing what you're trying to accomplish; use a gerund."
     end
   end
 end

--- a/src/tools/toolsets/experimental/patch_text_file_tool.cr
+++ b/src/tools/toolsets/experimental/patch_text_file_tool.cr
@@ -22,10 +22,10 @@ module Tools::Experimental
                         "`patch` command (version #{self.class.patch_version}). " +
                         "Ensures the file is within the current directory and is a text file."
 
-    param "file_path", type: Param::Type::Str,
-      description: "The relative path to the file to be patched.", required: true
-    param "patch_content", type: Param::Type::Str,
-      description: "The content of the patch to apply.", required: true
+    param "file_path", type: Param::Type::Str, required: true,
+      description: "The relative path to the file to be patched."
+    param "patch_content", type: Param::Type::Str, required: true,
+      description: "The content of the patch to apply."
 
     # Replace `runner` macro to create with self
     def new_runner : Runner

--- a/src/tools/toolsets/experimental/regex_edit_tool.cr
+++ b/src/tools/toolsets/experimental/regex_edit_tool.cr
@@ -11,12 +11,12 @@ module Tools::Experimental
     description "Finds patterns using a regex in a text-based file and replaces them with new text. " +
                 "Ensures the file is within the current directory and is a text file."
 
-    param "file_path", type: Param::Type::Str,
-      description: "The relative path to the file where you want to perform the regex replacement.", required: true
-    param "pattern", type: Param::Type::Str,
-      description: "The regex pattern to search for in the file.", required: true
-    param "replacement", type: Param::Type::Str,
-      description: "The text to replace the pattern with in the file.", required: true
+    param "file_path", type: Param::Type::Str, required: true,
+      description: "The relative path to the file where you want to perform the regex replacement."
+    param "pattern", type: Param::Type::Str, required: true,
+      description: "The regex pattern to search for in the file."
+    param "replacement", type: Param::Type::Str, required: true,
+      description: "The text to replace the pattern with in the file."
 
     runner Runner
 

--- a/src/tools/toolsets/file_management/create_directory_tool.cr
+++ b/src/tools/toolsets/file_management/create_directory_tool.cr
@@ -11,8 +11,8 @@ module Tools::FileManagement
 
     description "Creates a new directory at the specified relative path within the current directory."
 
-    param "directory_path", type: Param::Type::Str,
-      description: "The relative path of the directory to create.", required: true
+    param "directory_path", type: Param::Type::Str, required: true,
+      description: "The relative path of the directory to create."
 
     runner Runner
 

--- a/src/tools/toolsets/file_management/delete_file_tool.cr
+++ b/src/tools/toolsets/file_management/delete_file_tool.cr
@@ -14,8 +14,8 @@ module Tools::FileManagement
                 "with a ms-resolution timestamp prepended to the filename. This allows for file recovery if deletion " \
                 "was accidental. The directory structure is preserved in the `#{FileHelper::DELETED_FILES_PATH}` folder."
 
-    param "file_path", type: Param::Type::Str,
-      description: "The path of the file to be deleted.", required: true
+    param "file_path", type: Param::Type::Str, required: true,
+      description: "The path of the file to be deleted."
 
     runner Runner
 

--- a/src/tools/toolsets/file_management/find_files_tool.cr
+++ b/src/tools/toolsets/file_management/find_files_tool.cr
@@ -13,16 +13,16 @@ module Tools::FileManagement
     description "Finds files and directories in a directory hierarchy by matching a glob pattern."
 
     # Define the acceptable parameter using the `param` method
-    param "path", required: false,
-      description: "The starting point from where this tool looks for " \
-                   "files and directories matching the path pattern. Defaults to \".\" if not" \
-                   "specified. Cannot be empty."
     param "expression", required: true,
       description: "The glob pattern expression with which to find matching files and directories. "
+    param "path", required: false,
+      description: "Optional. The starting point from where this tool looks for " \
+                   "files and directories matching the path pattern. Defaults to \".\" if not" \
+                   "specified or empty string."
     param "max", type: Param::Type::Num, required: false,
-      description: "Maxmimum number of matches to return (default is #{FileHelper::MAX_FIND_FILE_MATCHES})"
+      description: "Optional. Maxmimum number of matches to return (default is #{FileHelper::MAX_FIND_FILE_MATCHES})"
     param "sort", type: Param::Type::Bool, required: false,
-      description: "Set to false to disable sorting (default is true)"
+      description: "Optional. Set to false to disable sorting (default is true)"
 
     runner Runner
 
@@ -34,9 +34,7 @@ module Tools::FileManagement
         pattern = args["expression"]?.try(&.as_s?) || return error_response("The required glob `expression` was not specified")
 
         start = args["path"]?.try(&.as_s?) || "."
-        if start.empty?
-          return error_response("Empty `path` not allowed; use `.` for current directory.")
-        end
+        start = "." if start.empty?
 
         max = args["max"]?.try(&.as_i?) || MAX_FIND_FILE_MATCHES
         sort = args["sort"]?.try(&.as_bool?)

--- a/src/tools/toolsets/file_management/rename_file_tool.cr
+++ b/src/tools/toolsets/file_management/rename_file_tool.cr
@@ -11,10 +11,10 @@ module Tools::FileManagement
     description "Rename a file or directory, or move it to another sub-folder, but you may not move it outside this directory." \
                 "like the `mv` command but restricted to the current folder."
 
-    param "source_path", type: Param::Type::Str,
-      description: "The current path of the file or directory to be renamed.", required: true
-    param "target_path", type: Param::Type::Str,
-      description: "The new name / path for the file or directory.", required: true
+    param "source_path", type: Param::Type::Str, required: true,
+      description: "The current path of the file or directory to be renamed."
+    param "target_path", type: Param::Type::Str, required: true,
+      description: "The new name / path for the file or directory."
 
     runner Runner
 

--- a/src/tools/toolsets/file_management/search_files_tool.cr
+++ b/src/tools/toolsets/file_management/search_files_tool.cr
@@ -14,12 +14,12 @@ module Tools::FileManagement
 
     param "files", required: true,
       description: "A single file path, or a glob pattern expression with which to find matching files."
-    param "pattern", type: Param::Type::Str,
-      description: "The text or pattern to search for in each file.", required: true
+    param "pattern", type: Param::Type::Str, required: true,
+      description: "The text or pattern to search for in each file."
     param "search_regex", type: Param::Type::Bool, required: false,
-      description: "Optional, set to true to indicate `search_pattern` is a regular expression (default is false.)"
+      description: "Optional. Set to true to indicate `search_pattern` is a regular expression (default is false.)"
     param "max_files", type: Param::Type::Num,
-      description: "Optional, maxmimum number of files to search within (default is #{FileHelper::MAX_FIND_FILE_MATCHES})"
+      description: "Optional. Maxmimum number of files to search within (default is #{FileHelper::MAX_FIND_FILE_MATCHES})"
 
     runner Runner
 

--- a/src/tools/toolsets/image_editing/create_image_file_tool.cr
+++ b/src/tools/toolsets/image_editing/create_image_file_tool.cr
@@ -12,13 +12,12 @@ module Tools::ImageEditing
     description "Creates an image file from base64 encoded image data at the specified path. " \
                 "Ensures the file is created within the current directory and does not overwrite existing files."
 
-    param "file_path", type: Param::Type::Str,
-      description: "The relative path where the image file will be created.", required: true
-    param "image_data", type: Param::Type::Str,
+    param "file_path", type: Param::Type::Str, required: true,
+      description: "The relative path where the image file will be created."
+    param "image_data", type: Param::Type::Str, required: true,
       description: "The base64 encoded image data in the format of a data URL " \
                    "('data:<content_type>;base64,<data>'). Supported content types are: " \
-                   "#{ImageHelper::ALLOWED_IMAGE_CONTENT_TYPES.join(',')}",
-      required: true
+                   "#{ImageHelper::ALLOWED_IMAGE_CONTENT_TYPES.join(',')}"
 
     runner Runner
 

--- a/src/tools/toolsets/image_editing/read_image_file_tool.cr
+++ b/src/tools/toolsets/image_editing/read_image_file_tool.cr
@@ -14,7 +14,8 @@ module Tools::ImageEditing
                 "Ensures the file is within the current directory and is a valid image file."
 
     # Define the acceptable parameter using the `param` method
-    param "file_path", type: Param::Type::Str, description: "The relative path to the image file to read.", required: true
+    param "file_path", type: Param::Type::Str, required: true,
+      description: "The relative path to the image file to read."
 
     runner Runner
 

--- a/src/tools/toolsets/shell_access/shell_command_tool.cr
+++ b/src/tools/toolsets/shell_access/shell_command_tool.cr
@@ -51,8 +51,8 @@ module Tools::ShellAccess
                         "#{allowed_commands.join(", ")}"
 
     # Define the acceptable parameter using the `param` method
-    param "command", type: Param::Type::Str,
-      description: "The shell command to execute.", required: true
+    param "command", type: Param::Type::Str, required: true,
+      description: "The shell command to execute."
 
     # Replace `runner` macro to create with self
     def new_runner : Runner

--- a/src/tools/toolsets/text_editing/read_text_file_tool.cr
+++ b/src/tools/toolsets/text_editing/read_text_file_tool.cr
@@ -17,11 +17,11 @@ module Tools::TextEditing
     param "file_path", type: Param::Type::Str, required: true,
       description: "The path to the text file to read."
     param "include_line_numbers", type: Param::Type::Bool, required: false,
-      description: "If true, prepends 1-indexed line numbers like `cat -n`. Defaults to false."
+      description: "Optional. Set to true to include line numbers, like `cat -n`. Defaults to false."
     param "line_range", type: Param::Type::Arr, required: false,
-      description: "An array of two integers specifying the start and end line numbers to view." \
+      description: "Optional. An array of two integers specifying the start and end line numbers to view." \
                    "Line numbers are 1-indexed, and -1 for the end line means read to the end of the file." \
-                   "Defaults to entire file."
+                   "Defaults to [1, -1] for entire file."
 
     runner Runner
 

--- a/src/tools/toolsets/text_editing/replace_text_file_tool.cr
+++ b/src/tools/toolsets/text_editing/replace_text_file_tool.cr
@@ -12,14 +12,14 @@ module Tools::TextEditing
     description "Replaces a specified string in a text file within the current directory with a new string." \
                 "This is used for making precise edits."
 
-    param "file_path", type: Param::Type::Str,
-      description: "The relative path to the text file to modify.", required: true
-    param "old_str", type: Param::Type::Str,
-      description: "The text to replace (must match exactly, including whitespace and indentation)", required: true
-    param "new_str", type: Param::Type::Str,
-      description: "The new text to insert in place of the old text.", required: true
+    param "file_path", type: Param::Type::Str, required: true,
+      description: "The relative path to the text file to modify."
+    param "old_str", type: Param::Type::Str, required: true,
+      description: "The text to replace (must match exactly, including whitespace and indentation)"
+    param "new_str", type: Param::Type::Str, required: true,
+      description: "The new text to insert in place of the old text."
     param "multiple", type: Param::Type::Bool, required: false,
-      description: "If true, tries to replaces multiple occurrences of the old string. Default is false, replacing only the first occurence."
+      description: "Optional. If true, tries to replaces multiple occurrences of the old string. Default is false, replacing only the first occurence."
 
     runner Runner
 

--- a/src/tools/toolsets/text_editing/write_text_file_tool.cr
+++ b/src/tools/toolsets/text_editing/write_text_file_tool.cr
@@ -11,9 +11,12 @@ module Tools::TextEditing
     description "Create a text file within the current directory and write the given content. " \
                 "Create entire path to the file if needed. DOES NOT overwrite existing file unless requested."
 
-    param "file_path", type: Param::Type::Str, description: "The relative path where the text file will be created.", required: true
-    param "overwrite", type: Param::Type::Bool, description: "Set to true to overwrite existing file; default is false.", required: false
-    param "content", type: Param::Type::Str, description: "The content to write into the text file.", required: true
+    param "file_path", type: Param::Type::Str, required: true,
+      description: "The relative path where the text file will be created."
+    param "content", type: Param::Type::Str, required: true,
+      description: "The content to write into the text file."
+    param "overwrite", type: Param::Type::Bool, required: false,
+      description: "Optional. Set to true to overwrite existing file; default is false."
 
     runner Runner
 


### PR DESCRIPTION
### Enhancements

- Add support for console style sheet that can be used to customize the console output based on style categories
  - Added a `console` configuration property, which supports `style_sheet` property. Here's an example. See documentation for all the supported style categories.
    ```yml
    console:
      style_sheet:
        after_reply: # style the time taken status after reply
          fg: magenta
          format: [underline, italic]
    ```

### Tweaks

Various tweaks as part of getting ready for 0.9.0 release.
- Remove deprecated `system_prompt` property in config file
- Improve how we ask for tool call reason by asking for a "gerund"
- Clearly state tool parameters are optional.