### PR TITLE
Make waiting suck less and fix protocol bug

### DIFF
--- a/release_notes/v0.9.0-pre.md
+++ b/release_notes/v0.9.0-pre.md
@@ -35,9 +35,13 @@
 - Add always-available built-in tools that a model can use to list and install tools.
   - `list_installable_tools` lists all tools available to install.
   - `install_tools` confirms with user before installing tools
-- Make the LLM request processing asynchronous, allowing Enkaidu to show a spinner whenever it was waiting on the LLM / model server.
+- Make some of the LLM request processing asynchronous, allowing Enkaidu to show a spinner when waiting on the LLM / model server.
 
 #### REMOVED
 
 - Previously deprecated `/session pop_and_take` command is now removed. Use `/session pop retain=...`, it's better.
 - Previously deprecated `system_prompt` config property is not removed. Define system prompts and refer to them by the `system_prompt_name` property instead.
+
+#### MISCELLANEOUS
+
+- Termify takes over as Markdown renderer for all modes.

--- a/release_notes/v0.9.0-pre.md
+++ b/release_notes/v0.9.0-pre.md
@@ -6,6 +6,10 @@
 - Improved rendering _reasoning_ boundaries when streaming to the console
 - Improved how tool calling is reported (as they occur), and how failing tool calls are handled (by replying to model with an error response)
 
+#### FIXES
+
+- Fixed a bug in the chat/completion protocol handling where received tool calls (while processed) were not included in the session history. Since tool call results were being sent but the session did not include the call request, sometimes and unpredictably this caused weird behaviour by the server / model. It was infrequent enough that it felt like hallucinatory bugs.
+
 #### FEATURES
 
 - Support quiet mode, available  via `--quiet` or `-Q` commandline flag, as well as via session config `quiet:`.
@@ -31,6 +35,7 @@
 - Add always-available built-in tools that a model can use to list and install tools.
   - `list_installable_tools` lists all tools available to install.
   - `install_tools` confirms with user before installing tools
+- Make the LLM request processing asynchronous, allowing Enkaidu to show a spinner whenever it was waiting on the LLM / model server.
 
 #### REMOVED
 

--- a/shard.lock
+++ b/shard.lock
@@ -10,11 +10,11 @@ shards:
 
   base58:
     git: https://github.com/crystal-china/base58.cr.git
-    version: 0.1.0+git.commit.f7193c497efff614cf87b03f0bd07741915a592f
+    version: 0.1.0+git.commit.0e2c44d16a8098b00d8bf0b74add8bb9ea2f1c5f
 
   crimage:
     git: https://github.com/naqvis/crimage.git
-    version: 1.0.4+git.commit.b65f67df27f4cb8807a34d94a90dfd4162acf45a
+    version: 1.0.5+git.commit.2b3abbcdca426a2a13a39b986326f9a2f7f65bc6
 
   docopt:
     git: https://github.com/ralsina/docopt.cr.git
@@ -31,18 +31,6 @@ shards:
   liquid:
     git: https://github.com/amberframework/liquid.cr.git
     version: 1.0.0
-
-  markd:
-    git: https://github.com/icyleaf/markd.git
-    version: 0.5.0+git.commit.03cd4f5d6f4e56054502a6548b4c2ff92fb3dc20
-
-  markterm:
-    git: https://github.com/ralsina/markterm.git
-    version: 0.7.0
-
-  progress_bar:
-    git: https://github.com/mgomes/progress_bar.git
-    version: 1.0.1+git.commit.aa5ebab89d31167208387640db06d3964ec7922b
 
   reply:
     git: https://github.com/i3oris/reply.git

--- a/shard.yml
+++ b/shard.yml
@@ -23,18 +23,18 @@ dependencies:
   json-schema:
     github: spider-gazelle/json-schema
     version: 1.3.2
-  markterm:
-    github: ralsina/markterm
-    version: 0.7.0
-    # --- markterm already pulls in ...
-    # baked_file_system:
-    #   github: schovi/baked_file_system
   reply:
     github: I3oris/reply
     version: 0.4.0
   html5:
     github: naqvis/crystal-html5
     version: 0.7.0
+  # --- tartrazine from termify already pulls in ...
+  #     noting this since Enkaidu uses this shard directly
+  # baked_file_system:
+  #   github: schovi/baked_file_system
+  #   version: 0.13.0
+  # ------
 
 targets:
   enkaidu:

--- a/src/enkaidu/cli/main.cr
+++ b/src/enkaidu/cli/main.cr
@@ -23,18 +23,15 @@ module Enkaidu::CLI
 
     WELCOME_FIRST_LEFT  = "│ Enkaidu #{VERSION} │ /help for commands │ #{ALT_KEY}-Enter multi-line input │ Tab auto-complete"
     WELCOME_SECOND_LEFT = "│ Welcome to your second-in-command(-line) agentic assistant for AI that YOU control!"
-    WELCOME_THIRD_LEFT  = "│ FYI │ Markdown rendering is experimental when streaming."
 
-    WELCOME_WIDTH = [WELCOME_FIRST_LEFT.size, WELCOME_SECOND_LEFT.size, WELCOME_THIRD_LEFT.size].max
+    WELCOME_WIDTH = [WELCOME_FIRST_LEFT.size, WELCOME_SECOND_LEFT.size].max
 
     WELCOME_FIRST_RIGHT  = (" " * ((WELCOME_WIDTH - WELCOME_FIRST_LEFT.size) + 2)) + '│'
     WELCOME_SECOND_RIGHT = (" " * ((WELCOME_WIDTH - WELCOME_SECOND_LEFT.size) + 2)) + '│'
-    WELCOME_THIRD_RIGHT  = (" " * ((WELCOME_WIDTH - WELCOME_THIRD_LEFT.size) + 2)) + '│'
 
     WELCOME_FIRST_COLOR = "│ #{"Enkaidu".colorize.bold} #{VERSION} │ " \
                           "#{"/help".colorize(:yellow)} for commands │ #{"#{ALT_KEY}-Enter".colorize(:yellow)} multi-line input │ #{"Tab".colorize(:yellow)} auto-complete"
-    WELCOME_THIRD_COLOR = "│ #{"FYI".colorize.bold} │ Markdown rendering is #{"experimental".colorize.bold} when streaming."
-    WELCOME_QUIET_BAR   = "─" * (WELCOME_FIRST_LEFT.size + WELCOME_FIRST_RIGHT.size - 2)
+    WELCOME_QUIET_BAR = "─" * (WELCOME_FIRST_LEFT.size + WELCOME_FIRST_RIGHT.size - 2)
 
     PROMPT_PRERELEASE = "CAUTION! #{VERSION} is a PRE-RELEASE in development.".colorize(:red)
 
@@ -50,11 +47,6 @@ module Enkaidu::CLI
         print '├', WELCOME_QUIET_BAR, '┤', '\n'
         print WELCOME_SECOND_LEFT.colorize.bold
         puts WELCOME_SECOND_RIGHT
-      end
-      if opts.stream? || opts.config.session.try(&.streaming?)
-        print '├', WELCOME_QUIET_BAR, '┤', '\n'
-        print WELCOME_THIRD_COLOR.colorize(:yellow).italic
-        puts WELCOME_THIRD_RIGHT
       end
       print '└', WELCOME_QUIET_BAR, '┘', '\n'
     end

--- a/src/enkaidu/cli/query_reader.cr
+++ b/src/enkaidu/cli/query_reader.cr
@@ -33,7 +33,7 @@ module Enkaidu::CLI
       if doc = @doc_cache[{{name}}]?
         doc
       elsif help = {{doc_generator}}
-        @doc_cache[{{name}}] = Markd.to_term(help)
+        @doc_cache[{{name}}] = styler.markdown_to_term(help)
       end
     end
 

--- a/src/enkaidu/console/console.cr
+++ b/src/enkaidu/console/console.cr
@@ -3,6 +3,5 @@ require "termify"
 require "colorize"
 
 require "../session_renderer"
-require "markterm"
 
 require "./renderer"

--- a/src/enkaidu/console/renderer.cr
+++ b/src/enkaidu/console/renderer.cr
@@ -1,6 +1,5 @@
 require "termify"
 require "colorize"
-require "markterm"
 
 require "./style_sheet"
 require "./input_reader"
@@ -51,10 +50,19 @@ module Enkaidu::Console
       merge: Termify::Markdown::Stylesheet.default
     )
 
+    # Render Markdown to string using Termify
+    def markdown_to_term(text)
+      String.build do |str_io|
+        Termify.render_markdown(str_io, style_sheet: MDR_STYLESHEET) do |io|
+          io << text.to_s
+        end
+      end
+    end
+
     private getter input = InputReader.new("> ")
 
     private def prepare_text(help, markdown)
-      markdown ? Markd.to_term(help.to_s) : help
+      markdown ? markdown_to_term(help.to_s) : help
     end
 
     private def err_puts_text(help, markdown)
@@ -229,7 +237,10 @@ module Enkaidu::Console
 
     private def render_streaming_markdown(text, _starting : Bool, ending : Bool)
       @md_renderer << text
-      @md_renderer.puts if ending
+      if ending
+        @md_renderer.puts
+        @md_renderer.flush
+      end
     end
 
     def llm_text(text, reasoning : Bool, starting : Bool = false, ending : Bool = false)
@@ -264,7 +275,7 @@ module Enkaidu::Console
     def llm_text_block(text, reasoning : Bool)
       puts unless reasoning
       puts fmt(:thinking_content, REASONING_START) if reasoning
-      puts Markd.to_term(text)
+      puts markdown_to_term(text)
       puts fmt(:thinking_content, REASONING_FINISH) if reasoning
       puts unless reasoning
     end

--- a/src/enkaidu/console/style_sheet.cr
+++ b/src/enkaidu/console/style_sheet.cr
@@ -165,5 +165,8 @@ module Enkaidu::Console
       # Return text as is if formatting fails
       text
     end
+
+    # Render Markdown to string
+    abstract def markdown_to_term(text)
   end
 end

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -1,6 +1,5 @@
 require "json"
 require "option_parser"
-require "markterm"
 require "uuid"
 
 require "../llm"
@@ -254,19 +253,17 @@ module Enkaidu
     # Perform tool calls and subsequent events repeatedly until
     # no more tool calls remain
     private def consume_tool_calls(tools)
+      # Cannot do this concurrently since tool calls can prompt user
+      # for input
       until tools.empty?
         calls = tools
-        ev_queue = queue_chat_request do |queue|
-          spawn do
-            chat.call_tools_and_ask calls do |event|
-              queue << event
-              Fiber.yield
-            end
-            queue << {type: "DONE", content: JSON::Any.new(nil)}
-          end
-        end
         tools = [] of JSON::Any
-        gather_and_handle(ev_queue, tools)
+        ix = 0
+        prev_event = nil
+        chat.call_tools_and_ask calls do |event|
+          m_process_and_record_ask_event(event, prev_event)
+          prev_event = event
+        end
       end
     end
 

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -256,7 +256,7 @@ module Enkaidu
     private def consume_tool_calls(tools)
       until tools.empty?
         calls = tools
-        queue = queue_chat_request do |queue|
+        ev_queue = queue_chat_request do |queue|
           spawn do
             chat.call_tools_and_ask calls do |event|
               queue << event
@@ -266,7 +266,7 @@ module Enkaidu
           end
         end
         tools = [] of JSON::Any
-        gather_and_handle(queue, tools)
+        gather_and_handle(ev_queue, tools)
       end
     end
 
@@ -315,7 +315,7 @@ module Enkaidu
       tools = [] of JSON::Any
       # ask and handle the initial query and its events
       report_time_taken(prefix: "Total ") do
-        queue = queue_chat_request do |queue|
+        ev_queue = queue_chat_request do |queue|
           spawn do
             chat.re_ask(response_schema: response_json_schema) do |event|
               queue << event
@@ -325,7 +325,7 @@ module Enkaidu
           end
         end
         # Process events in queue
-        gather_and_handle(queue, tools)
+        gather_and_handle(ev_queue, tools)
         consume_tool_calls(tools)
       end
       recorder << "]"
@@ -347,7 +347,7 @@ module Enkaidu
         # ask and handle the initial query and its events
         renderer.user_query_text(query) if render_query
         # Run the chat query concurrently
-        queue = queue_chat_request do |queue|
+        ev_queue = queue_chat_request do |queue|
           spawn do
             chat.ask(query, attach: attach, response_schema: response_json_schema) do |event|
               queue << event
@@ -357,7 +357,7 @@ module Enkaidu
           end
         end
         # Process events in queue
-        gather_and_handle(queue, tools)
+        gather_and_handle(ev_queue, tools)
         consume_tool_calls(tools)
       end
     ensure

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -5,6 +5,7 @@ require "uuid"
 
 require "../llm"
 require "../tools"
+require "../sucre/thread_safe"
 
 require "./about"
 require "./tools/*"
@@ -167,7 +168,7 @@ module Enkaidu
     end
 
     private macro m_process_and_record_ask_event(event, prev_event)
-    type = {{event}}["type"]
+      type = {{event}}["type"]
       unless type == "done"
         recorder.if_recording? do |io|
           io.puts "," if ix.positive?
@@ -252,25 +253,58 @@ module Enkaidu
 
     # Perform tool calls and subsequent events repeatedly until
     # no more tool calls remain
-    private def consume_tool_calls(tools, ix)
+    private def consume_tool_calls(tools)
       until tools.empty?
         calls = tools
-        tools = [] of JSON::Any
-        ev_count = 0
-        prev_event = nil
-        chat.call_tools_and_ask calls do |event|
-          ev_count += 1
-          unless event["type"] == "done"
-            recorder.if_recording? do |io|
-              io.puts "," if ix.positive?
-              io.puts event.to_json
+        queue = queue_chat_request do |queue|
+          spawn do
+            chat.call_tools_and_ask calls do |event|
+              queue << event
+              Fiber.yield
             end
-            ix += 1
-            process_event(event, prev_event) do |tool_call|
-              tools << tool_call
-            end
+            queue << {type: "DONE", content: JSON::Any.new(nil)}
           end
+        end
+        tools = [] of JSON::Any
+        gather_and_handle(queue, tools)
+      end
+    end
+
+    private def queue_chat_request(&) : TS::Queue(LLM::ChatEvent)
+      queue = TS::Queue(LLM::ChatEvent).new
+      yield queue
+      # Wait for events in a timed loop
+      spin_count = 0
+      while queue.empty?
+        STDERR.print "\r  Engaging #{spinner(spin_count)}".colorize(:dark_gray).italic
+        sleep(100.milliseconds)
+        spin_count += 1
+      end
+      STDERR.print "\r\e[K"
+      # Return with queue to caller
+      queue
+    end
+
+    private def gather_and_handle(queue, tools) : Nil
+      # Process events in queue
+      ix = 0
+      spin_count = 0
+      prev_event = nil
+      loop do
+        if event = queue.shift?
+          break if event["type"].upcase == "DONE"
+
+          STDERR.print "\r\e[K" unless streaming?
+          m_process_and_record_ask_event(event, prev_event)
           prev_event = event
+        else
+          if streaming?
+            sleep(10.milliseconds)
+          else
+            STDERR.print "\r  Receiving #{spinner(spin_count)}".colorize(:dark_gray).italic
+            sleep(100.milliseconds)
+            spin_count += 1
+          end
         end
       end
     end
@@ -278,18 +312,29 @@ module Enkaidu
     # Re-query LLM using current session history
     private def re_ask(response_json_schema : LLM::ResponseSchema? = nil)
       recorder << "["
-      ix = 0
       tools = [] of JSON::Any
       # ask and handle the initial query and its events
       report_time_taken(prefix: "Total ") do
-        prev_event = nil
-        chat.re_ask(response_schema: response_json_schema) do |event|
-          m_process_and_record_ask_event(event, prev_event)
-          prev_event = event
+        queue = queue_chat_request do |queue|
+          spawn do
+            chat.re_ask(response_schema: response_json_schema) do |event|
+              queue << event
+              Fiber.yield
+            end
+            queue << {type: "DONE", content: JSON::Any.new(nil)}
+          end
         end
-        consume_tool_calls(tools, ix)
+        # Process events in queue
+        gather_and_handle(queue, tools)
+        consume_tool_calls(tools)
       end
       recorder << "]"
+    end
+
+    private SPINNER = ['|', '/', '-', '\\']
+
+    private def spinner(count)
+      SPINNER[count % SPINNER.size]
     end
 
     # Query LLM using a prompt and optional attachments
@@ -297,17 +342,23 @@ module Enkaidu
             response_json_schema : LLM::ResponseSchema? = nil,
             render_query = false)
       recorder << "["
-      ix = 0
       tools = [] of JSON::Any
       report_time_taken(prefix: "Total ") do
         # ask and handle the initial query and its events
         renderer.user_query_text(query) if render_query
-        prev_event = nil
-        chat.ask(query, attach: attach, response_schema: response_json_schema) do |event|
-          m_process_and_record_ask_event(event, prev_event)
-          prev_event = event
+        # Run the chat query concurrently
+        queue = queue_chat_request do |queue|
+          spawn do
+            chat.ask(query, attach: attach, response_schema: response_json_schema) do |event|
+              queue << event
+              Fiber.yield
+            end
+            queue << {type: "DONE", content: JSON::Any.new(nil)}
+          end
         end
-        consume_tool_calls(tools, ix)
+        # Process events in queue
+        gather_and_handle(queue, tools)
+        consume_tool_calls(tools)
       end
     ensure
       recorder << "]"

--- a/src/enkaidu/session/lifecycle.cr
+++ b/src/enkaidu/session/lifecycle.cr
@@ -121,12 +121,11 @@ module Enkaidu
         when "reasoning"
           renderer.llm_text_block(chat_ev["content"].as_s, reasoning: true)
           text_count += 1
-        when "tool_call"
+        when "tool_call_requested"
           text_count = 0
           renderer.llm_tool_call(
             name: chat_ev["content"].dig("function", "name").as_s,
             args: chat_ev["content"].dig("function", "arguments"))
-        when "tool_called"
         when "query/text"
           renderer.user_query_text(chat_ev["content"].as_s)
           text_count += 1

--- a/src/enkaidu/wui/event_renderer.cr
+++ b/src/enkaidu/wui/event_renderer.cr
@@ -2,7 +2,6 @@ require "../session_renderer"
 require "./work"
 require "./render_events/*"
 
-require "markterm"
 require "reply"
 
 module Enkaidu::WUI

--- a/src/llm.cr
+++ b/src/llm.cr
@@ -4,4 +4,6 @@ require "./llm/azure_openai"
 require "./llm/ollama"
 
 module LLM
+  # Development use; set to `true` to trace HTTP
+  TRACE = false
 end

--- a/src/llm/connection.cr
+++ b/src/llm/connection.cr
@@ -14,6 +14,10 @@ module LLM
     end
 
     protected def post_and_stream(body, &)
+      if TRACE
+        STDERR.puts ">>> POST #{path}" if TRACE
+        STDERR.puts ">>> #{headers}" if TRACE
+      end
       @client.post(path, headers,
         body: body) do |resp|
         yield resp

--- a/src/llm/openai/chat.cr
+++ b/src/llm/openai/chat.cr
@@ -126,11 +126,11 @@ module LLM::OpenAI
           append_message call_tool(tool, call)
         else
           yield unknown_tool_call(call)
-          error_calling_tool(
+          append_message error_calling_tool(
             call.dig("id").as_s,
             name,
             error: "The tool #{name} is not installed. Consider installing it first.",
-            instruction: "IMPORTANT: YOU MUST install a tool BEFORE you can call it")
+          )
         end
         calls += 1
       end

--- a/src/llm/openai/chat.cr
+++ b/src/llm/openai/chat.cr
@@ -212,7 +212,7 @@ module LLM::OpenAI
             content = msg["content"].to_s
           when "reasoning"
             reasoning = msg["content"].to_s
-          when "tool_call"
+          when "tool_call_requested"
             tool_calls << msg["content"]
           when "usage"
             usage = Usage.from_json(msg["content"].to_json)
@@ -273,7 +273,7 @@ module LLM::OpenAI
       # close up recent tool call
       call = jsonify_function_call(recent_tool_call)
       tool_calls << call
-      {type: "tool_call", content: call}
+      {type: "tool_call_requested", content: call}
     end
 
     # ameba:disable Metrics/CyclomaticComplexity: It's too messy if I split this up more.
@@ -301,7 +301,7 @@ module LLM::OpenAI
                 when "reasoning"
                   think_io << msg["content"]
                   yield msg
-                when "tool_call"
+                when "tool_call_requested"
                   yield(wrap_up_tool_call(recent_tool_call, tool_calls)) if recent_tool_call
                   # and start a new one
                   recent_tool_call = extract_tool_call_from_message(msg)

--- a/src/llm/openai/chat/message/response.cr
+++ b/src/llm/openai/chat/message/response.cr
@@ -32,7 +32,7 @@ module LLM::OpenAI
       end
       tool_calls.try &.each do |call|
         yield({
-          type:    "tool_call",
+          type:    "tool_call_requested",
           content: call,
         })
       end

--- a/src/llm/openai/openai.cr
+++ b/src/llm/openai/openai.cr
@@ -3,6 +3,4 @@ require "./connection"
 # The `OpenAI` module lets you connect and chat with
 # OpenAI-compatible LLM servers.
 module LLM::OpenAI
-  # Development use; set to `true` to trace HTTP
-  TRACE = false
 end

--- a/src/sucre/thread_safe/queue.cr
+++ b/src/sucre/thread_safe/queue.cr
@@ -24,12 +24,12 @@ module TS
 
     # Return `true` if queue is empty
     def empty? : Bool
-      ex_queue.lock { |queue| queue.empty? }
+      ex_queue.lock(&.empty?)
     end
 
     # Shift item from the top of the queue, or `nil?` if empty
     def shift? : T?
-      ex_queue.lock { |queue| queue.shift? }
+      ex_queue.lock(&.shift?)
     end
   end
 end

--- a/src/sucre/thread_safe/queue.cr
+++ b/src/sucre/thread_safe/queue.cr
@@ -1,0 +1,35 @@
+require "sync/exclusive"
+
+module TS
+  # A thread-safe queue backed by an exclusive lock on the queue array
+  class Queue(T)
+    private getter ex_queue : Sync::Exclusive(Array(T))
+
+    def initialize
+      @ex_queue = Sync::Exclusive(Array(T)).new([] of T)
+    end
+
+    # Add item to the end of the queue
+    def add(value : T) : self
+      ex_queue.lock do |queue|
+        queue << value
+      end
+      self
+    end
+
+    # :ditto:
+    def <<(value : T) : self
+      add(value)
+    end
+
+    # Return `true` if queue is empty
+    def empty? : Bool
+      ex_queue.lock { |queue| queue.empty? }
+    end
+
+    # Shift item from the top of the queue, or `nil?` if empty
+    def shift? : T?
+      ex_queue.lock { |queue| queue.shift? }
+    end
+  end
+end

--- a/src/sucre/thread_safe/thread_safe.cr
+++ b/src/sucre/thread_safe/thread_safe.cr
@@ -1,0 +1,6 @@
+# All data structures in this module provide thread-safety and
+# concurrency safety.
+module TS
+end
+
+require "./queue"

--- a/src/tools/toolsets/file_management/create_directory_tool.cr
+++ b/src/tools/toolsets/file_management/create_directory_tool.cr
@@ -21,7 +21,7 @@ module Tools::FileManagement
       include FileHelper
 
       def execute(args : JSON::Any) : String
-        dir_path = args["directory_path"].as_s? || return error_response("The required directory_path was not specified")
+        dir_path = args["directory_path"]?.try(&.as_s?) || return error_response("The required directory_path was not specified")
         resolved_path = resolve_path(dir_path)
 
         # Ensure the path stays within the current working directory

--- a/src/tools/toolsets/file_management/delete_file_tool.cr
+++ b/src/tools/toolsets/file_management/delete_file_tool.cr
@@ -24,7 +24,7 @@ module Tools::FileManagement
       include FileHelper
 
       def execute(args : JSON::Any) : String
-        file_path = args["file_path"].as_s? || return error_response("The required file_path was not specified")
+        file_path = args["file_path"]?.try(&.as_s?) || return error_response("The required file_path was not specified")
 
         resolved_file_path = resolve_path(file_path)
 

--- a/src/tools/toolsets/file_management/rename_file_tool.cr
+++ b/src/tools/toolsets/file_management/rename_file_tool.cr
@@ -23,8 +23,8 @@ module Tools::FileManagement
       include FileHelper
 
       def execute(args : JSON::Any) : String
-        current_path = args["source_path"].as_s? || return error_response("The required `source_path` was not specified")
-        new_name = args["target_path"].as_s? || return error_response("The required `target_path` was not specified")
+        current_path = args["source_path"]?.try(&.as_s?) || return error_response("The required `source_path` was not specified")
+        new_name = args["target_path"]?.try(&.as_s?) || return error_response("The required `target_path` was not specified")
 
         resolved_current_path = resolve_path(current_path)
         resolved_new_path = resolve_path(File.join(File.dirname(resolved_current_path), new_name))

--- a/src/tools/toolsets/text_editing/read_text_file_tool.cr
+++ b/src/tools/toolsets/text_editing/read_text_file_tool.cr
@@ -30,7 +30,7 @@ module Tools::TextEditing
       include FileHelper
 
       def execute(args : JSON::Any) : String
-        file_path = args["file_path"].as_s? || return error_response("The required `file_path` was not specified")
+        file_path = args["file_path"]?.try(&.as_s?) || return error_response("The required `file_path` was not specified")
         line_numbers = args["include_line_numbers"]?.try &.as_bool? || false
         line_range = if range = args["line_range"]?
                        if (arr = range.as_a?) && arr.size == 2 && (line_start = arr[0]?.try(&.as_i?)) && (line_end = arr[1]?.try(&.as_i?))

--- a/src/tools/toolsets/text_editing/write_text_file_tool.cr
+++ b/src/tools/toolsets/text_editing/write_text_file_tool.cr
@@ -25,8 +25,8 @@ module Tools::TextEditing
       include FileHelper
 
       def execute(args : JSON::Any) : String
-        file_path = args["file_path"].as_s? || return error_response("The required file_path was not specified")
-        content = args["content"].as_s? || return error_response("The required content was not specified")
+        file_path = args["file_path"]?.try(&.as_s?) || return error_response("The required file_path was not specified")
+        content = args["content"]?.try(&.as_s?) || return error_response("The required content was not specified")
         overwrite = args["overwrite"]?.try(&.as_bool?) || false
 
         resolved_path = resolve_path(file_path)

--- a/src/tools/toolsets/web/http_get_web_page_as_markdown.cr
+++ b/src/tools/toolsets/web/http_get_web_page_as_markdown.cr
@@ -33,7 +33,7 @@ module Tools::Web
       USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:146.0) Gecko/20100101 Firefox/146.0"
 
       def execute(args : JSON::Any) : String
-        url = args["url"].as_s? || return error_response("The required URL was not specified")
+        url = args["url"]?.try(&.as_s?) || return error_response("The required URL was not specified")
         user_agent = args["user_agent"]?.try(&.as_s?) || USER_AGENT
 
         headers = HTTP::Headers{

--- a/src/tools/toolsets/web/http_get_web_page_tool.cr
+++ b/src/tools/toolsets/web/http_get_web_page_tool.cr
@@ -41,7 +41,7 @@ module Tools::Web
       USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:146.0) Gecko/20100101 Firefox/146.0"
 
       def execute(args : JSON::Any) : String
-        url = args["url"].as_s? || return error_response("The required URL was not specified")
+        url = args["url"]?.try(&.as_s?) || return error_response("The required URL was not specified")
         user_agent = args["user_agent"]?.try(&.as_s?) || USER_AGENT
         preserve_source = args["preserve_source"]? || false
         accept = args["accept"]?.try(&.as_s?) || nil


### PR DESCRIPTION

#### FIXES

- Fixed a bug in the chat/completion protocol handling where received tool calls (while processed) were not included in the session history. Since tool call results were being sent but the session did not include the call request, sometimes and unpredictably this caused weird behaviour by the server / model. It was infrequent enough that it felt like hallucinatory bugs.

#### FEATURES

- Make the LLM request processing asynchronous, allowing Enkaidu to show a spinner whenever it was waiting on the LLM / model server.

#### MISCELLANEOUS

- Termify takes over as Markdown renderer for all modes.

