### PR TITLE
Improve the safety and convenience knobs for the `shell_command`

### DIFF
--- a/release_notes/v0.9.2.md
+++ b/release_notes/v0.9.2.md
@@ -1,0 +1,12 @@
+
+#### IMPROVEMENTS
+
+- Improved the safety and convenience knobs for the `shell_command` in the `ShellAccess` toolset
+  - Adding a `restricted_terms` setting that you can use to add terms that when present always require confirmation
+  - There is a baseline set of reestricted terms which are always present.
+  - Commands split in case they are multiple commands via pipes, separators, operators
+  - Each split command is checked for safety, which increases the detection surface when commands are piped
+  - Checking against the "approved" and "allowed" lists is as follows:
+    - MUST MATCH entire command, or
+    - MUST PREFIX MATCH command with subsequent space.
+  - This means you can _allow_ a base command (e.g. `git`) and _approve_ a subcommand (e.g. `git status`), thus requiring confirmation for all other `git` subcommmands.

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: enkaidu
-version: 0.9.1
+version: 0.9.2
 license: MPL-2.0
 description: Command line tool that can use local and remote AI models to assist
   with local editing and refinement tasks.

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -312,6 +312,7 @@ module Enkaidu
               queue << event
               Fiber.yield
             end
+          ensure
             queue << {type: "DONE", content: JSON::Any.new(nil)}
           end
         end
@@ -344,6 +345,7 @@ module Enkaidu
               queue << event
               Fiber.yield
             end
+          ensure
             queue << {type: "DONE", content: JSON::Any.new(nil)}
           end
         end

--- a/src/tools/toolsets/shell_access/shell_command_tool.cr
+++ b/src/tools/toolsets/shell_access/shell_command_tool.cr
@@ -11,44 +11,80 @@ module Tools::ShellAccess
     # The `SafetyError` class is used to indicate that a command is unsafe for execution due to its content.
     class SafetyError < Exception; end
 
-    UNSAFE_STRINGS = ["..", "|", "<", ">", ";", "&"]
+    # Forbidden strings cause commands to fail
+    # Restricted strings always require confirmation
+
+    {% if flag?(:windows) %}
+      # In Windows commands, & is unconditional separate, like ';' in Linux. Don't forbid.
+      FORBIDDEN_STRINGS  = ["..", "<", ">"]
+      MULTI_CMD_SPLIT_RX = /(\|\|)|(&&)|[;|&]/
+      ALWAYS_RESTRICTED  = ["rm", "del", "eval", "for", "--expression", "-e ", "-e=", "|", ";"].map(&.upcase)
+    {% else %}
+      # In *nix commands, & is for background execution, so we forbid it.
+      FORBIDDEN_STRINGS  = ["..", "<", ">", "&"]
+      MULTI_CMD_SPLIT_RX = /(\|\|)|(&&)|[;|]/
+      ALWAYS_RESTRICTED  = ["rm", "eval", "$(", "--expression", "-e ", "-e=", "|", ";"].map(&.upcase)
+    {% end %}
 
     @allowed_cmds : Array(String)? = nil
     @approved_cmds : Array(String)? = nil
+    @restricted_terms : Array(String)? = nil
+
+    # -----
+    # Approved and Allowed commands are tested as prefixes. This allows allowed commands to include
+    # subcommands. Note that a command must match one of the allowed/approved command prefixes EXACTLY
+    # or the command MUST BEGIN WITH allowed/approved command PLUS A SPACE.
+    #
+    # i.e. if "crystal" is allowed, it must be called exactly `cmd == "crystal"` or
+    # must match the start with a subsequent space `cmd.starts_with?("crystal ")`
+    # -----
 
     # Allowed commands can be specified via tool settings in the config file, or
     # via `ENKAIDU_ALLOWED_EXECUTABLES` environment variable, with config taking priority.
     # Approved commands are includes in the allowed commands list.
     def allowed_commands : Array(String)
       @allowed_cmds ||= approved_commands |
-                        case value = (settings.try &.["allowed_commands"]?)
-                        when Array(String) then value
-                        when String        then [value]
-                        else
-                          ENV.fetch("ENKAIDU_ALLOWED_EXECUTABLES", "ls cat grep whoami file wc find").split(" ")
-                        end
+                        extract_setting("allowed_commands", "ENKAIDU_ALLOWED_EXECUTABLES", "grep whoami file wc")
     end
 
     # Approved commands can be specified via tool settings in the config file, or
     # via `ENKAIDU_APPROVED_EXECUTABLES` environment variable, with config taking priority.
     def approved_commands : Array(String)
-      @approved_cmds ||= case value = (settings.try &.["approved_commands"]?)
-                         when Array(String) then value
-                         when String        then [value]
-                         else
-                           ENV.fetch("ENKAIDU_APPROVED_EXECUTABLES", nil).try(&.split(" ")) || [] of String
-                         end
+      @approved_cmds ||= extract_setting("approved_commands", "ENKAIDU_APPROVED_EXECUTABLES")
+    end
+
+    # Additional restricted terms can be specified via tool settings in the config file.
+    # Commands are checked if they are present ANYWHERE within.
+    def restricted_terms : Array(String)
+      @restricted_terms ||= ALWAYS_RESTRICTED |
+                            extract_setting("restricted_terms", "ENKAIDU_RESTRICTED_TERMS")
+    end
+
+    # Retrieve a setting if present, or env variable if present, or default if specified
+    private def extract_setting(name, env_fallback, default : String? = nil)
+      case value = (settings.try &.[name]?)
+      when Array(String) then value
+      when String        then [value]
+      else
+        ENV.fetch(env_fallback, default).try(&.split(" ")) || [] of String
+      end
     end
 
     name "shell_command"
 
+    COMMON_DESCRIPTION = "Executes one of the allowed shell commands from within the " \
+                         "current project's directory and returns the shell command's output." \
+                         "Commands with restricted terms always require approval."
     # Provide a description for the tool
-    static_description "Executes one of the allowed shell commands from within the " \
-                       "current project's root directory and returns the shell command's output."
+    static_description <<-DESC
+    #{COMMON_DESCRIPTION}
+    DESC
 
-    runtime_description "Executes one of the following allowed shell commands from within the " \
-                        "current project's root directory and returns the shell command's output: " \
-                        "#{allowed_commands.join(", ")}"
+    runtime_description <<-DESC
+    #{COMMON_DESCRIPTION}
+
+    Allowed commands: #{allowed_commands.join(", ")}
+    DESC
 
     # Define the acceptable parameter using the `param` method
     param "command", type: Param::Type::Str, required: true,
@@ -66,15 +102,23 @@ module Tools::ShellAccess
       def initialize(@func); end
 
       def execute(args : JSON::Any) : String
-        command = args["command"].as_s? || return error_response("The required 'command' was not specified.")
+        command = args["command"]?.try(&.as_s?) || return error_response("The required 'command' was not specified.")
+        command = command.strip
+        return error_response("The required 'command' was empty.") if command.empty?
 
         begin
-          check_safety(command)
-
-          if requires_confirmation?(command)
-            raise PermissionError.new("User denied execution.") unless user_confirms?(command)
+          # Split multiple commands if any so we can check each
+          # Non-Windows: && splitting won't work for now since & is forbidden
+          multi_commands = command.split(MULTI_CMD_SPLIT_RX).map(&.strip)
+          # Make sure each command if safe
+          multi_commands.each { |cmd| check_safety(cmd) }
+          # gather up any restricted terms
+          found_restricted = restricted_terms_in(command)
+          # do any of the commands require confirmation?
+          if !found_restricted.empty? || multi_commands.any? { |cmd| requires_confirmation?(cmd) }
+            raise PermissionError.new("User denied execution.") unless user_confirms?(command, found_restricted)
           end
-
+          # Now we can execute the command
           output = `#{command} 2>&1`
           success_response(command, output)
         rescue e
@@ -83,33 +127,41 @@ module Tools::ShellAccess
       end
 
       def check_safety(command)
-        unless func.allowed_commands.any? { |cmd| command.index("#{cmd} ") == 0 }
-          if command.split(' ', 2).size == 1
-            raise SafetyError.new("The `#{command}` command must specify arguments. Bare commands not allowed yet.")
-          else
-            raise SafetyError.new("Only the following commands are allowed: #{func.allowed_commands.join(", ")}.")
-          end
+        # MUST prefix-match
+        unless func.allowed_commands.any? { |cmd| command == cmd || command.starts_with?("#{cmd} ") }
+          raise SafetyError.new("Only the following commands are allowed: #{func.allowed_commands.join(", ")}.")
         end
 
-        UNSAFE_STRINGS.each do |str|
-          if command.includes?(str)
-            raise SafetyError.new("The following strings are not allowed: #{UNSAFE_STRINGS.join(", ")}")
-          end
+        if FORBIDDEN_STRINGS.any? { |str| command.includes?(str) }
+          raise SafetyError.new("The command contains some of the following forbidden strings: #{FORBIDDEN_STRINGS.join(", ")}")
         end
 
+        # Command matches allowed list, and contains no unsafe strings
         true
       end
 
-      def requires_confirmation?(command)
-        if (name = command.split(' ', 2).first) && func.approved_commands.includes?(name)
-          false
-        else
-          true
-        end
+      # Returns all restricted terms (array of strings) found in the command
+      def restricted_terms_in(command) : Array(String)
+        cmd = command.upcase
+        # check case insensitively
+        func.restricted_terms.select { |term| cmd.includes?(term) }
       end
 
-      def user_confirms?(command)
-        func.renderer.user_confirm_shell_command?(command)
+      def requires_confirmation?(command)
+        if func.approved_commands.any? { |cmd| command == cmd || command.starts_with?("#{cmd} ") }
+          # And approved command detected
+          return false # good to go
+        end
+        # Confirmation required
+        true
+      end
+
+      def user_confirms?(command, found_restricted)
+        has_restricted = " AND contains restricted terms: #{found_restricted.join(", ")}" unless found_restricted.empty?
+        func.renderer.user_confirm_security_question?(
+          description: "The agent's AI model wants to run the following system command#{has_restricted || ""}",
+          subject: command
+        )
       end
 
       # Create a success response as a JSON string


### PR DESCRIPTION
### What?

- Improved the safety and convenience knobs for the `shell_command` in the `ShellAccess` toolset
  - Adding a `restricted_terms` setting that you can use to add terms that when present always require confirmation
  - There is a baseline set of reestricted terms which are always present.
  - Commands split in case they are multiple commands via pipes, separators, operators
  - Each split command is checked for safety, which increases the detection surface when commands are piped
  - Checking against the "approved" and "allowed" lists is as follows:
    - MUST MATCH entire command, or
    - MUST PREFIX MATCH command with subsequent space.
  - This means you can _allow_ a base command (e.g. `git`) and _approve_ a subcommand (e.g. `git status`), thus requiring confirmation for all other `git` subcommmands.

### Why?

The current handling of _allowed_ and _approved_ was slightly inconsistent. Also, we only checked the whole command, and clearly we should do more.

Adding prefix-matching actually helps reduce friction. E.g. You can **allow** `crystal` and **approve** `crystal spec` since the latter runs thetest specs while any other subcommand should be approved.