### PR TITLE
Allow multiple Enkaidu Web UI sessions, and show session info

### DIFF
--- a/release_notes/v0.9.3-pre.md
+++ b/release_notes/v0.9.3-pre.md
@@ -1,0 +1,7 @@
+
+#### IMPROVEMENTS
+
+- Launching Enkaidu in Web UI mode now launches the server with an unused port instead of the previously fixed port.
+  - This means we can run `enkaidu --webui` from different locations **at the same time** and work with each in a separate browser tab.
+- Enkaidu Web UI after the first prompt in a session will show the current working directory _and_ host name.
+  - When running multiple `enkaidu --webui` sessions you can now distinguish which one is from which project.

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: enkaidu
-version: 0.9.2
+version: 0.9.3-pre
 license: MPL-2.0
 description: Command line tool that can use local and remote AI models to assist
   with local editing and refinement tasks.

--- a/src/enkaidu/session/toolsets.cr
+++ b/src/enkaidu/session/toolsets.cr
@@ -6,7 +6,7 @@ module Enkaidu
       def list_all_tools
         text = String.build do |io|
           chat.each_tool_origin do |origin|
-            io << "## " << origin << '\n'
+            io << "### " << origin << '\n'
             chat.each_tool(origin: origin) do |tool|
               io << "`" << tool.name << "` : "
               io << tool.description << "\n\n"

--- a/src/enkaidu/wui/event_renderer.cr
+++ b/src/enkaidu/wui/event_renderer.cr
@@ -53,7 +53,8 @@ module Enkaidu::WUI
     end
 
     def time_elapsed(duration : Time::Span, label : String? = nil)
-      info_with("#{label}#{duration.total_seconds}s elapsed.")
+      elapsed = duration.total_seconds.format(decimal_places: 3, only_significant: true)
+      info_with("#{label}#{elapsed}s elapsed.")
     end
 
     def user_query_text(query, via_query_queue = false)

--- a/src/enkaidu/wui/main.cr
+++ b/src/enkaidu/wui/main.cr
@@ -69,7 +69,8 @@ module Enkaidu
         console.info_with WELCOME_MSG, WELCOME, markdown: true
         console.info_with ""
 
-        @web_server = WebServer.new(8765,
+        port = ENV.fetch("ENKAIDU_PORT", nil).try(&.to_i32?)
+        @web_server = WebServer.new(port,
           bind_to_all_nics: ENV.fetch("ENKAIDU_BIND_TO_ALL", nil) != nil)
 
         queue.info_with(WELCOME_MSG, WELCOME, markdown: true)
@@ -115,6 +116,7 @@ module Enkaidu
 
         web_server.get "/api/start" do |_, resp|
           list = gather_queue_events
+          list.unshift(WUI::Render::SystemInfo.new)
           list.each { |line| resp.puts line.to_json }
         end
 

--- a/src/enkaidu/wui/render_events/system.cr
+++ b/src/enkaidu/wui/render_events/system.cr
@@ -1,0 +1,14 @@
+require "./event"
+
+module Enkaidu::WUI::Render
+  class SystemInfo < Event
+    getter host
+    getter cwd
+
+    def initialize
+      super "system_info"
+      @cwd = Dir.current
+      @host = System.hostname
+    end
+  end
+end

--- a/src/sucre/web_server/web_server.cr
+++ b/src/sucre/web_server/web_server.cr
@@ -8,7 +8,6 @@ class WebServer
     EndServer
   end
 
-  getter port : Int32
   getter address : Socket::IPAddress
 
   private alias HandlerProc = Proc(HTTP::Request, HTTP::Server::Response, Nil)
@@ -18,15 +17,25 @@ class WebServer
   private getter work_finished = Channel(Bool).new
   private getter active_handlers = 0
 
-  def initialize(@port, bind_to_all_nics = false)
+  # Listen on specified `port`, or bind to an unused port which you can identify after via `#port` method.
+  def initialize(port : Int32? = nil, bind_to_all_nics = false)
     @server = HTTP::Server.new do |context|
       handle(context)
     end
-    @address = if bind_to_all_nics
+    @address = if bind_to_all_nics && port.is_a?(Int)
                  @server.bind_tcp "0.0.0.0", port
+               elsif bind_to_all_nics
+                 @server.bind_unused_port "0.0.0.0"
+               elsif port.nil?
+                 @server.bind_unused_port
                else
                  @server.bind_tcp port
                end
+  end
+
+  # Port number the server is listening on
+  def port : Int32
+    @address.port
   end
 
   private def start_tracking

--- a/webui/src/App.svelte
+++ b/webui/src/App.svelte
@@ -9,6 +9,7 @@
   // import Sidebar from "./lib/Sidebar.svelte";
 
   let session: Session;
+  let menubar: Menubar;
   let prompt: Promptbar;
 
   let started = false;
@@ -16,7 +17,7 @@
 
   async function read_line_by_line(
     response: Response,
-    handler: (line: string | null) => void,
+    handler: (line: string | null) => void
   ) {
     const reader = response.body?.getReader();
     if (!reader) return;
@@ -59,12 +60,15 @@
       if (line != null && line.length > 0) {
         let msg = JSON.parse(line);
         switch (msg.type) {
+          case "system_info":
+            menubar.update(msg.host, msg.cwd);
+            break;
           case "ask_for_inputs":
             session.ask_for_inputs(
               msg.id,
               msg.title,
               msg.arguments,
-              msg.description,
+              msg.description
             );
             break;
           case "message":
@@ -163,7 +167,7 @@
             session.show_security_confirmation(
               msg.description,
               msg.subject,
-              msg.id,
+              msg.id
             );
             break;
           case "session_reset":
@@ -201,7 +205,7 @@
       });
       let resp = await enkaidu_post_request(
         "prompt",
-        new_prompt_request(query),
+        new_prompt_request(query)
       );
       await handle_response(resp);
     } catch (error) {
@@ -223,7 +227,7 @@
     <input id="my-drawer" type="checkbox" class="drawer-toggle" />
     <div class="drawer-content">
       <div class="flex flex-col h-screen justify-between">
-        <Menubar />
+        <Menubar bind:this={menubar} host="" cwd="" />
         <Session bind:this={session} />
         <Promptbar
           bind:this={prompt}

--- a/webui/src/App.svelte
+++ b/webui/src/App.svelte
@@ -151,16 +151,9 @@
             break;
           case "llm_tool_call":
             session.add_event({
-              type: `message_success`,
-              subject: `CALL "${msg.name}" with`,
-              content: "`" + msg.args + "`",
-            });
-            break;
-          case "llm_tool_call":
-            session.add_event({
-              type: `message_success`,
-              subject: `CALL "${msg.name}" with`,
-              content: "`" + msg.args + "`",
+              type: `tool_call`,
+              subject: msg.name,
+              content: msg.args,
             });
             break;
           case "security_confirmation":

--- a/webui/src/lib/AsstTextCard.svelte
+++ b/webui/src/lib/AsstTextCard.svelte
@@ -8,12 +8,11 @@
 </script>
 
 <div
-  class="card bg-base-300 text-base-content card-sm shadow-sm w-7/8 place-self-start py-1 dark:border-accent dark:border-1"
+  class="indicator card bg-base-100 text-base-content card-sm shadow-none w-7/8"
+  // class="indicator card bg-base-200 text-base-content card-sm shadow-sm w-7/8 place-self-start py-1 dark:border-accent dark:border-1"
 >
   <ContentUtilities copy_text={message} />
-
   <div class="card-body py-1">
-    <h2 class="card-title text-sm text-accent">Assistant</h2>
     <Markdown content={message} />
   </div>
 </div>

--- a/webui/src/lib/AsstThinkCard.svelte
+++ b/webui/src/lib/AsstThinkCard.svelte
@@ -6,14 +6,19 @@
 </script>
 
 <div
-  class="card bg-base-200 text-base-content italic card-xs shadow-sm w-7/8 place-self-start dark:border-accent dark:border-1"
+  class="card bg-none mb-0 text-base-content italic card-xs shadow-none w-7/8 place-self-start"
+  // class="card bg-base-200 text-base-content italic card-xs shadow-sm w-7/8 place-self-start dark:border-accent dark:border"
 >
   <div class="collapse collapse-arrow py-0">
     <input type="checkbox" />
-    <div class="collapse-title card-title py-0 text-ghost text-xs">
+    <div
+      class="collapse-title card-title py-0 text-ghost text-xs after:inset-s-5 after:inset-e-auto pe-4 ps-10"
+    >
       Thinking
     </div>
-    <div class="collapse-content text-base text-sm">
+    <div
+      class="collapse-content text-base ms-6 ps-2 border-l-2 border-l-gray-400"
+    >
       <Markdown content={message} add_class="text-sm" />
     </div>
   </div>

--- a/webui/src/lib/AsstThinkCard.svelte
+++ b/webui/src/lib/AsstThinkCard.svelte
@@ -6,11 +6,13 @@
 </script>
 
 <div
-  class="card bg-base-100 text-base-content italic card-xs shadow-sm w-7/8 place-self-start dark:border-accent dark:border-1"
+  class="card bg-base-200 text-base-content italic card-xs shadow-sm w-7/8 place-self-start dark:border-accent dark:border-1"
 >
-  <div class="collapse collapse-arrow">
+  <div class="collapse collapse-arrow py-0">
     <input type="checkbox" />
-    <div class="collapse-title card-title text-ghost text-xs">Thinking</div>
+    <div class="collapse-title card-title py-0 text-ghost text-xs">
+      Thinking
+    </div>
     <div class="collapse-content text-base text-sm">
       <Markdown content={message} add_class="text-sm" />
     </div>

--- a/webui/src/lib/AsstThinkCard.svelte
+++ b/webui/src/lib/AsstThinkCard.svelte
@@ -6,15 +6,13 @@
 </script>
 
 <div
-  class="card bg-base-300 text-base-content py-1 italic card-sm shadow-sm w-7/8 place-self-start dark:border-accent dark:border-1"
+  class="card bg-base-100 text-base-content italic card-xs shadow-sm w-7/8 place-self-start dark:border-accent dark:border-1"
 >
-  <div class="collapse collapse-arrow py-1">
+  <div class="collapse collapse-arrow">
     <input type="checkbox" />
-    <div class="collapse-title card-title text-accent text-sm">
-      Assistant &lt;THINK&gt;
-    </div>
-    <div class="collapse-content text-base">
-      <Markdown content={message} />
+    <div class="collapse-title card-title text-ghost text-xs">Thinking</div>
+    <div class="collapse-content text-base text-sm">
+      <Markdown content={message} add_class="text-sm" />
     </div>
   </div>
 </div>

--- a/webui/src/lib/ContentUtilities.svelte
+++ b/webui/src/lib/ContentUtilities.svelte
@@ -18,9 +18,10 @@
   }
 </script>
 
-<div class="absolute px-1 pe-2 w-full flex place-content-end">
+<div class="indicator-item">
+  <!-- <div class="absolute px-1 pe-2 flex place-content-end"> -->
   <div class="tooltip tooltip-bottom" data-tip="Copy">
-    <button class="btn btn-outline btn-xs {copy_state}" onclick={copy}>
+    <button class="btn btn-solid btn-xs {copy_state}" onclick={copy}>
       {#if copy_state == ""}
         <Copy />
       {:else}

--- a/webui/src/lib/ContentUtilities.svelte
+++ b/webui/src/lib/ContentUtilities.svelte
@@ -18,10 +18,13 @@
   }
 </script>
 
-<div class="indicator-item">
-  <!-- <div class="absolute px-1 pe-2 flex place-content-end"> -->
+<!-- <div class="absolute "> -->
+<div class="absolute w-full px-1 flex place-content-end">
   <div class="tooltip tooltip-bottom" data-tip="Copy">
-    <button class="btn btn-solid btn-xs {copy_state}" onclick={copy}>
+    <button
+      class="btn btn-accent btn-soft btn-solid btn-xs {copy_state}"
+      onclick={copy}
+    >
       {#if copy_state == ""}
         <Copy />
       {:else}

--- a/webui/src/lib/Menubar.svelte
+++ b/webui/src/lib/Menubar.svelte
@@ -1,9 +1,28 @@
 <script lang="ts">
+  import Folder from "virtual:icons/pixelarticons/folder";
+  import Server from "virtual:icons/pixelarticons/server";
+
+  let { host, cwd }: { host: string; cwd: string } = $props();
+
+  export function update(hostname, workingpath) {
+    host = hostname;
+    cwd = workingpath;
+  }
 </script>
 
 <div
   class="navbar bg-secondary text-secondary-content min-h-auto py-2 shadow-md justify-between"
 >
-  <kbd class="kbd kbd-xl text-secondary">Enkaidu</kbd>
+  <span
+    ><kbd class="kbd kbd-xl text-secondary">Enkaidu</kbd>
+    <b>:{window.location.port}</b></span
+  >
+  <div class="badge badge-lg badge-secondary">
+    <Folder /> <b>{cwd}</b>
+  </div>
+
+  <div class="badge badge-lg badge-secondary">
+    <Server /><b>{host}</b>
+  </div>
   <!-- <label for="my-drawer" class="btn btn-ghost drawer-button"> &lt;&lt; </label> -->
 </div>

--- a/webui/src/lib/MsgCard.svelte
+++ b/webui/src/lib/MsgCard.svelte
@@ -10,34 +10,56 @@
 </script>
 
 <div
-  class="indicator w-7/8 p-1 card card-xs shadow-sm place-self-start bg-base-100 text-sm text-base-content dark:border-base-content dark:border-1 dark:border-dashed"
+  class="indicator w-7/8 py-0 card card-xs shadow-sm place-self-start bg-base-200 text-sm text-base-content dark:border-base-content dark:border-1 dark:border-dashed"
 >
   {#if level == "warn"}
-    <span class="indicator-item badge badge-sm badge-warning">WARN</span>
+    <span
+      class="indicator-item indicator-center badge badge-sm badge-soft badge-warning"
+      >WARN</span
+    >
   {:else if level == "success"}
-    <span class="indicator-item badge badge-sm badge-success">OK</span>
+    <span
+      class="indicator-item indicator-center badge badge-sm badge-soft badge-success"
+      >OK</span
+    >
   {:else if level == "error"}
-    <span class="indicator-item badge badge-sm badge-error">ERROR</span>
+    <span
+      class="indicator-item indicator-center badge badge-sm badge-soft badge-error"
+      >ERROR</span
+    >
   {:else if level == "info"}
-    <span class="indicator-item badge badge-sm badge-info">INFO</span>
+    <span
+      class="indicator-item indicator-center badge badge-sm badge-soft badge-info"
+      >INFO</span
+    >
   {:else}
-    <span class="indicator-item badge badge-sm badge-error"
+    <span
+      class="indicator-item indicator-center badge badge-sm badge-soft badge-error"
       >{`?(${level})?`}</span
     >
   {/if}
-  {#each data as msg}
-    {#if msg.content}
-      <div class="collapse collapse-arrow">
-        <input type="checkbox" />
-        <div class="collapse-title card-title text-xs">
-          {msg.subject}
-        </div>
-        <div class="collapse-content text-xs">
-          <Markdown content={msg.content} add_class="text-sm" />
-        </div>
+
+  {#if data.length > 1}
+    <div class="collapse py-0 collapse-arrow">
+      <input type="checkbox" />
+      <div class="collapse-title py-0 card-title text-xs">
+        {data[0].subject}
       </div>
-    {:else}
-      <p>{msg.subject}</p>
-    {/if}
-  {/each}
+      <div class="collapse-content py-0 text-xs">
+        {#each data as msg}
+          {#if msg.content}
+            <Markdown content={msg.content} add_class="text-sm pl-5" />
+          {:else if msg != data[0]}
+            <div class="card-title text-xs">
+              {msg.subject}
+            </div>
+          {/if}
+        {/each}
+      </div>
+    </div>
+  {:else}
+    <div class="card-title py-2 ps-4 text-xs">
+      {data[0].subject}
+    </div>
+  {/if}
 </div>

--- a/webui/src/lib/MsgCard.svelte
+++ b/webui/src/lib/MsgCard.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <div
-  class="indicator w-7/8 p-1 card card-sm shadow-sm place-self-start bg-base-200 text-sm text-base-content dark:border-base-content dark:border-1 dark:border-dashed"
+  class="indicator w-7/8 p-1 card card-xs shadow-sm place-self-start bg-base-100 text-sm text-base-content dark:border-base-content dark:border-1 dark:border-dashed"
 >
   {#if level == "warn"}
     <span class="indicator-item badge badge-sm badge-warning">WARN</span>
@@ -29,11 +29,11 @@
     {#if msg.content}
       <div class="collapse collapse-arrow">
         <input type="checkbox" />
-        <div class="collapse-title card-title text-sm">
+        <div class="collapse-title card-title text-xs">
           {msg.subject}
         </div>
-        <div class="collapse-content text-sm">
-          <Markdown content={msg.content} />
+        <div class="collapse-content text-xs">
+          <Markdown content={msg.content} add_class="text-sm" />
         </div>
       </div>
     {:else}

--- a/webui/src/lib/MsgCard.svelte
+++ b/webui/src/lib/MsgCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Markdown from "./Markdown.svelte";
+  import MsgLevel from "./MsgLevel.svelte";
 
   type MessageData = {
     subject?: string | undefined;
@@ -10,56 +11,49 @@
 </script>
 
 <div
-  class="indicator w-7/8 py-0 card card-xs shadow-sm place-self-start bg-base-200 text-sm text-base-content dark:border-base-content dark:border-1 dark:border-dashed"
+  class="indicator w-7/8 py-0 card card-xs shadow-none place-self-start bg-base-200 border-0 text-sm text-base-content"
+  // class="indicator w-7/8 py-0 card card-xs shadow-sm place-self-start bg-base-200 text-sm text-base-content dark:border-base-content dark:border-1 dark:border-dashed"
 >
-  {#if level == "warn"}
-    <span
-      class="indicator-item indicator-center badge badge-sm badge-soft badge-warning"
-      >WARN</span
-    >
-  {:else if level == "success"}
-    <span
-      class="indicator-item indicator-center badge badge-sm badge-soft badge-success"
-      >OK</span
-    >
-  {:else if level == "error"}
-    <span
-      class="indicator-item indicator-center badge badge-sm badge-soft badge-error"
-      >ERROR</span
-    >
-  {:else if level == "info"}
-    <span
-      class="indicator-item indicator-center badge badge-sm badge-soft badge-info"
-      >INFO</span
-    >
-  {:else}
-    <span
-      class="indicator-item indicator-center badge badge-sm badge-soft badge-error"
-      >{`?(${level})?`}</span
-    >
-  {/if}
-
-  {#if data.length > 1}
+  {#if data[0].content}
     <div class="collapse py-0 collapse-arrow">
       <input type="checkbox" />
-      <div class="collapse-title py-0 card-title text-xs">
-        {data[0].subject}
+      <div
+        class="collapse-title card-title py-0 text-ghost text-xs after:inset-s-5 after:inset-e-auto pe-4 ps-10"
+      >
+        <MsgLevel {level} />{data[0].subject}
       </div>
       <div class="collapse-content py-0 text-xs">
-        {#each data as msg}
-          {#if msg.content}
-            <Markdown content={msg.content} add_class="text-sm pl-5" />
-          {:else if msg != data[0]}
-            <div class="card-title text-xs">
-              {msg.subject}
-            </div>
-          {/if}
-        {/each}
+        {#if data.length > 0}
+          <!-- Multiple data lines, so gather then all together -->
+          {#each data as msg}
+            {#if msg.content}
+              <Markdown
+                content={msg.content}
+                add_class="text-sm ms-2 ps-2 border-l-gray-400 border-l-2"
+              />
+            {:else if msg != data[0]}
+              <div
+                class="card-title text-xs ms-2 ps-2 border-l-gray-400 border-l-2"
+              >
+                {msg.subject}
+              </div>
+            {/if}
+          {/each}
+        {:else}
+          <!--  Single data line -->
+          <div class="collapse-content py-0 text-xs">
+            <Markdown
+              content={data[0].content}
+              add_class="text-sm ms-2 ps-2 border-l-gray-400 border-l-2"
+            />
+          </div>
+        {/if}
       </div>
     </div>
   {:else}
+    <!-- Single subject only, no body -->
     <div class="card-title py-2 ps-4 text-xs">
-      {data[0].subject}
+      <MsgLevel {level} />{data[0].subject}
     </div>
   {/if}
 </div>

--- a/webui/src/lib/MsgLevel.svelte
+++ b/webui/src/lib/MsgLevel.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  let { level }: { level: string } = $props();
+</script>
+
+{#if level == "warn"}
+  <span class="badge badge-sm badge-soft badge-warning">WARN</span>
+{:else if level == "success"}
+  <span class="badge badge-sm badge-soft badge-success">OK</span>
+{:else if level == "error"}
+  <span class="badge badge-sm badge-soft badge-error">ERROR</span>
+{:else if level == "info"}
+  <span class="badge badge-sm badge-soft badge-info">INFO</span>
+{:else}
+  <span class="badge badge-sm badge-soft badge-error">{`?(${level})?`}</span>
+{/if}

--- a/webui/src/lib/Session.svelte
+++ b/webui/src/lib/Session.svelte
@@ -11,6 +11,7 @@
   import UserImageCard from "./UserImageCard.svelte";
   import ClarionCard from "./ClarionCard.svelte";
   import InputsDialog from "./InputsDialog.svelte";
+  import ToolCallCard from "./ToolCallCard.svelte";
 
   const scrollToBottom = (node: HTMLElement, _list: Event[]) => {
     const scroll = () =>
@@ -104,7 +105,7 @@
   export function show_security_confirmation(
     description: string,
     subject: string,
-    id: string,
+    id: string
   ) {
     security_confirm_dialog.show = true;
     security_confirm_dialog.description = description;
@@ -129,7 +130,7 @@
     id: string,
     title: string,
     input_args: Common.InputArg[],
-    description?: string | undefined,
+    description?: string | undefined
   ) {
     inputs_dialog.show = true;
     inputs_dialog.id = id;
@@ -177,6 +178,11 @@
         <AsstImageCard image_url={entry.data[0].content || "??"} />
       {:else if entry.type == "clarion"}
         <ClarionCard subject={entry.data[0].content || "???"} />
+      {:else if entry.type == "tool_call"}
+        <ToolCallCard
+          name={entry.data[0].subject}
+          args={entry.data[0].content}
+        />
       {:else if entry.type.startsWith("message_")}
         <MsgCard
           level={entry.type.split("_").at(-1) || "info"}

--- a/webui/src/lib/ToolCallCard.svelte
+++ b/webui/src/lib/ToolCallCard.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import Markdown from "./Markdown.svelte";
+
+  let { name, args }: { name: string; args: string } = $props();
+  let params = JSON.parse(args);
+</script>
+
+<div
+  class="px-4 place-self-start bg-base-100 text-sm text-success"
+  // class=" w-7/8 px-4 py-1 card card-xs shadow-sm place-self-start bg-base-100 text-sm text-base-content dark:border-base-content dark:border-1 dark:border-dashed"
+>
+  <div class="card-title text-ghost text-xs">
+    <i>
+      {#if params.reason}
+        {params.reason} → CALL <code>{name}</code>
+      {:else}
+        → CALL <code>{name}</code> with <code>{args}</code>
+      {/if}
+    </i>
+  </div>
+</div>

--- a/webui/src/lib/ToolCallCard.svelte
+++ b/webui/src/lib/ToolCallCard.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import Markdown from "./Markdown.svelte";
-
   let { name, args }: { name: string; args: string } = $props();
+
+  // svelte-ignore state_referenced_locally
   let params = JSON.parse(args);
 </script>
 
 <div
-  class="px-4 place-self-start bg-base-100 text-sm text-success"
+  class="px-4 place-self-start mb-0 bg-base-100 text-sm text-success"
   // class=" w-7/8 px-4 py-1 card card-xs shadow-sm place-self-start bg-base-100 text-sm text-base-content dark:border-base-content dark:border-1 dark:border-dashed"
 >
   <div class="card-title text-ghost text-xs">

--- a/webui/src/lib/UserTextCard.svelte
+++ b/webui/src/lib/UserTextCard.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <div
-  class="card py-1 card-sm shadow-sm w-7/8 place-self-end {via_query_queue
+  class="indicator card py-1 card-sm shadow-sm w-7/8 place-self-end {via_query_queue
     ? 'bg-info'
     : 'bg-accent'}"
 >

--- a/webui/src/lib/UserTextCard.svelte
+++ b/webui/src/lib/UserTextCard.svelte
@@ -14,16 +14,16 @@
 </script>
 
 <div
-  class="indicator card py-1 card-sm shadow-sm w-7/8 place-self-end {via_query_queue
-    ? 'bg-info'
-    : 'bg-accent'}"
+  class="indicator card py-1 card-sm shadow-none w-7/8 bg-none border place-self-end {via_query_queue
+    ? 'border-info'
+    : 'border-accent'}"
 >
   <ContentUtilities copy_text={message} />
 
   <div class="card-body py-1">
     <Markdown
       content={command ? `\`${message}\`` : message}
-      add_class="text-accent-content"
+      add_class="text-gray-600 dark:text-gray-300"
     />
   </div>
 </div>

--- a/webui/src/utilities.ts
+++ b/webui/src/utilities.ts
@@ -1,8 +1,6 @@
 
-const ENKAIDU_API_BASE_URL = "http://localhost:8765/api"
-
 export async function enkaidu_get_request(path: string) {
-  const request = new Request(`${ENKAIDU_API_BASE_URL}/${path}`, {
+  const request = new Request(new URL(`/api/${path}`, window.location.href), {
     method: "GET",
   });
 
@@ -14,7 +12,7 @@ export async function enkaidu_post_request(path: string, content: any) {
     "Content-Type": "application/json",
   });
 
-  const request = new Request(`${ENKAIDU_API_BASE_URL}/${path}`, {
+  const request = new Request(new URL(`/api/${path}`, window.location.href), {
     method: "POST",
     body: JSON.stringify(content),
     headers: headers,

--- a/webui/src/utilities.ts
+++ b/webui/src/utilities.ts
@@ -1,6 +1,8 @@
 
+const ENKAIDU_URL = window.location.href
+
 export async function enkaidu_get_request(path: string) {
-  const request = new Request(new URL(`/api/${path}`, window.location.href), {
+  const request = new Request(new URL(`/api/${path}`, ENKAIDU_URL), {
     method: "GET",
   });
 
@@ -12,7 +14,7 @@ export async function enkaidu_post_request(path: string, content: any) {
     "Content-Type": "application/json",
   });
 
-  const request = new Request(new URL(`/api/${path}`, window.location.href), {
+  const request = new Request(new URL(`/api/${path}`, ENKAIDU_URL), {
     method: "POST",
     body: JSON.stringify(content),
     headers: headers,


### PR DESCRIPTION
### What?

- Launching Enkaidu in Web UI mode now launches the server with an unused port instead of the previously fixed port.
- Enkaidu Web UI after the first prompt in a session will show the current working directory _and_ host name.
- Cosmetic changes to better compact notification messages, less clutter with more compact collapsible think blocks. See screenshot below.

### Why?

- We can run `enkaidu --webui` from different locations **at the same time** and work with each in a separate browser tab.
- You can now distinguish which one is from which project.

### Screenshot

Dark | Light
---|----
<img width="1346" height="828" alt="Screenshot 2026-05-16 at 16-09-24 Enkaidu WebUI" src="https://github.com/user-attachments/assets/f4ed8957-d7ec-4a03-9292-adc91b876335" /> |  <img width="1346" height="826" alt="Screenshot 2026-05-16 at 16-09-32 Enkaidu WebUI" src="https://github.com/user-attachments/assets/08c3aa6b-8bd4-4a76-8c14-b03839b32a91" />




