### PR TITLE
Support invoking prompts (via `/prompt use`) with parameters

### DIFF
--- a/release_notes/v0.9.3-pre.md
+++ b/release_notes/v0.9.3-pre.md
@@ -5,3 +5,7 @@
   - This means we can run `enkaidu --webui` from different locations **at the same time** and work with each in a separate browser tab.
 - Enkaidu Web UI after the first prompt in a session will show the current working directory _and_ host name.
   - When running multiple `enkaidu --webui` sessions you can now distinguish which one is from which project.
+- Prompts can be invoked with parameters, in which case the user won't be prompted to enter the value for arguments with matching named parameters.
+  - E.g. `/prompt use describe lang=Rust` will not prompt user for the `lang` argument
+  - In the terminal, the prompt and value are shown but user is not asked.
+  - In the web UI, if all arguments have pre-filled values, the dialog window is not shown.

--- a/src/enkaidu/console/renderer.cr
+++ b/src/enkaidu/console/renderer.cr
@@ -306,7 +306,9 @@ module Enkaidu::Console
       puts fmt(:mcp_feedback, "  └─ prompt: #{prompt.name}")
     end
 
-    private def ask_param_input(name, description)
+    # Show parameter input prompt, and either present value if any or
+    # ask for value
+    private def ask_param_input(name, description, value)
       text = if description
                "    #{name} [#{description}] :"
              else
@@ -314,10 +316,16 @@ module Enkaidu::Console
              end
       puts fmt(:prompt_question, text)
       input.label = fmt(:prompt_input, "    > ")
-      input.read_next
+      if value
+        input.prompt(STDOUT, 0, true)
+        puts fmt(:prompt_auto_input, value)
+      else
+        value = input.read_next
+      end
+      value
     end
 
-    private def ask_prompt_inputs(prompt) : Hash(String, String)
+    private def ask_prompt_inputs(prompt, params : Hash? = nil) : Hash(String, String)
       text = <<-PREFIX
           #{prompt.description}
 
@@ -326,7 +334,10 @@ module Enkaidu::Console
 
       arg_inputs = {} of String => String
       prompt.arguments.try &.each do |arg|
-        unless (value = ask_param_input(arg.name, arg.description)).nil?
+        unless (value = ask_param_input(
+                 arg.name,
+                 arg.description,
+                 params.try(&.[arg.name]?).try(&.to_s))).nil?
           arg_inputs[arg.name] = value
         end
       end
@@ -338,8 +349,8 @@ module Enkaidu::Console
       ask_prompt_inputs(prompt)
     end
 
-    def user_prompt_ask_input(prompt : TemplatePrompt) : Hash(String, String)
-      ask_prompt_inputs(prompt)
+    def user_prompt_ask_input(prompt : TemplatePrompt, params : Hash? = nil) : Hash(String, String)
+      ask_prompt_inputs(prompt, params)
     end
 
     MCP_MAX_TOOL_CALL_ARGS_LENGTH = 72

--- a/src/enkaidu/console/style_sheet.cr
+++ b/src/enkaidu/console/style_sheet.cr
@@ -30,6 +30,7 @@ module Enkaidu::Console
     PromptQuestion
     PromptContent
     PromptInput
+    PromptAutoInput
     SessionBanner
     SessionOpen
     SessionClose
@@ -132,6 +133,7 @@ module Enkaidu::Console
         add :prompt_question, {fg: :cyan}
         add :prompt_content, {fg: :cyan, format: [:italic]}
         add :prompt_input, {fg: :white, format: [:bold]}
+        add :prompt_auto_input, {fg: :yellow}
         add :mcp_feedback, {fg: :light_blue}
         add :mcp_action, {fg: :light_blue, format: [:italic]}
       end

--- a/src/enkaidu/session/prompts.cr
+++ b/src/enkaidu/session/prompts.cr
@@ -44,7 +44,10 @@ module Enkaidu
         prompts_by_name[prompt_name]?
       end
 
-      def use_prompt(prompt_name, show = true, attach : LLM::ChatInclusions? = nil, response_schema : LLM::ResponseSchema? = nil)
+      def use_prompt(prompt_name,
+                     params : Hash? = nil,
+                     attach : LLM::ChatInclusions? = nil,
+                     response_schema : LLM::ResponseSchema? = nil)
         if prompt = find_prompt?(prompt_name)
           case prompt
           when MCPPrompt
@@ -58,9 +61,12 @@ module Enkaidu
               re_ask(response_json_schema: response_schema)
             end
           when TemplatePrompt
-            arg_inputs = renderer.user_prompt_ask_input(prompt)
+            arg_inputs = renderer.user_prompt_ask_input(prompt, params)
             prompt_text = prompt.render(arg_inputs, profile: opts.profile)
-            ask(query: prompt_text, attach: attach, response_json_schema: response_schema, render_query: show)
+            ask(query: prompt_text,
+              attach: attach,
+              response_json_schema: response_schema,
+              render_query: true)
           end
         end
       rescue ex

--- a/src/enkaidu/session_renderer.cr
+++ b/src/enkaidu/session_renderer.cr
@@ -33,7 +33,9 @@ module Enkaidu
     # @return True to confirm, false otherwise.
     abstract def user_confirm_security_question?(description, subject : String | Array(String)) : Bool
 
-    abstract def user_prompt_ask_input(prompt : TemplatePrompt) : Hash(String, String)
+    # Present prompt and ask for inputs if arguments are defined and no values are
+    # present in `params`.
+    abstract def user_prompt_ask_input(prompt : TemplatePrompt, params : Hash? = nil) : Hash(String, String)
 
     abstract def time_elapsed(duration : Time::Span, label : String? = nil)
 

--- a/src/enkaidu/slash/prompt.cr
+++ b/src/enkaidu/slash/prompt.cr
@@ -12,8 +12,10 @@ module Enkaidu::Slash
       - List all available prompt
     - `info <PROMPTNAME>`
       - Provide details about one prompt
-    - `use <PROMPTNAME>`
-      - Use (invoke) a prompt by name. If the prompt requirements arguments, you will be prompted for input per argument.
+    - `use <PROMPTNAME> [NAME=VALUE ...]`
+      - Use (invoke) a prompt by name.
+      - If the prompt requirements arguments, you will be prompted for input per argument.
+      - If you provide values for any arguments by name, those values will be used without prompting
     HELP1
 
     private getter commander : Commander
@@ -38,17 +40,38 @@ module Enkaidu::Slash
         session.list_all_prompts
       elsif cmd.expect?(NAME, "info", String)
         session.list_prompt_details((cmd.arg_at? 2).as(String))
-      elsif cmd.expect?(NAME, "use", String, show: ["yes", "no", nil])
-        show = cmd.arg_named?("show", "yes").try(&.==("yes"))
-        schema = commander.take_response_schema!
-        inclusions = commander.take_inclusions!
-        session.use_prompt(prompt_name: (cmd.arg_at? 2).as(String),
-          show: show, attach: inclusions, response_schema: schema)
+      elsif cmd.arg_at?(0).try(&.==(NAME)) && cmd.arg_at?(1).try(&.==("use"))
+        if (prompt = cmd.arg_at?(2)) && prompt.is_a?(String)
+          invoke_prompt(session, cmd, prompt)
+        else
+          session.renderer.warning_with(
+            "ERROR: Prompt name required to use a prompt",
+            help: HELP, markdown: true)
+        end
       else
         session.renderer.warning_with(
           "ERROR: Unknown or incomplete sub-command: #{cmd.arg_at? 0}",
           help: HELP, markdown: true)
       end
+    end
+
+    private def invoke_prompt(session, cmd, prompt)
+      # /macro use ...
+      # Gather up arguments, positional and named into a hash
+      # Positional ones with 0-index (from starting position) as key
+      # Named ones by names
+      params = {} of String => String | Array(String)
+      (2...cmd.positional_count).each do |i|
+        params[(i - 2).to_s] = cmd.arg_at(i)
+      end
+      cmd.each_named do |key, value|
+        params[key] = value
+      end
+      # Gather up attachment, response schema and call session
+      schema = commander.take_response_schema!
+      inclusions = commander.take_inclusions!
+      session.use_prompt(prompt_name: prompt, params: params,
+        attach: inclusions, response_schema: schema)
     end
   end
 end

--- a/src/enkaidu/wui/event_renderer.cr
+++ b/src/enkaidu/wui/event_renderer.cr
@@ -188,19 +188,32 @@ module Enkaidu::WUI
       result
     end
 
-    def user_prompt_ask_input(prompt : TemplatePrompt) : Hash(String, String)
+    def user_prompt_ask_input(prompt : TemplatePrompt, params : Hash? = nil) : Hash(String, String)
       return {} of String => String unless (args = prompt.arguments) && args.size.positive?
 
       input_id = Random::Secure.hex(16)
       input_channel = InputsChannel.new
       pending_inputs[input_id] = input_channel
 
-      post_event Render::AskForInputs.new(input_id, prompt)
+      # Extract argu values if any match
+      pre_filled = {} of String => String
+      prompt.arguments.each do |arg|
+        if value = params.try(&.[arg.name]?)
+          pre_filled[arg.name] = value.to_s
+        end
+      end
+      if pre_filled.size < prompt.arguments.size
+        # Not all arguments pre-filled
+        post_event Render::AskForInputs.new(input_id, prompt, pre_filled)
 
-      # Wait for the response
-      result = input_channel.receive
-      pending_inputs.delete(input_id)
-      result
+        # Wait for the response
+        result = input_channel.receive
+        pending_inputs.delete(input_id)
+        result
+      else
+        # Return all the pre-filled, don't prompt user
+        pre_filled
+      end
     end
 
     # Server handler calls to provide response to a pending confirmation request

--- a/src/enkaidu/wui/render_events/ask.cr
+++ b/src/enkaidu/wui/render_events/ask.cr
@@ -24,6 +24,7 @@ module Enkaidu::WUI::Render
     getter id : String
     getter description : String
     getter arguments : Array(InputArgument)
+    getter pre_filled : Hash(String, String)?
     getter title : String
 
     def initialize(@id, prompt : MCP::Prompt)
@@ -38,9 +39,10 @@ module Enkaidu::WUI::Render
           description: prompt_arg.description || prompt_arg.title,
           type: InputType::Text)
       end
+      @pre_filled = nil
     end
 
-    def initialize(@id, prompt : TemplatePrompt)
+    def initialize(@id, prompt : TemplatePrompt, @pre_filled = nil)
       prompt_args = prompt.arguments
 
       super("ask_for_inputs")

--- a/src/sucre/command_parser/command_parser.cr
+++ b/src/sucre/command_parser/command_parser.cr
@@ -97,6 +97,13 @@ class CommandParser
     @named_args[name.to_s]? || default
   end
 
+  # Iterate through the named arguments
+  def each_named(&)
+    @named_args.each do |name, value|
+      yield name, value
+    end
+  end
+
   # private TRACE = 1
 
   # Use this to see if the command matches expected arguments and parameters, where

--- a/webui/src/App.svelte
+++ b/webui/src/App.svelte
@@ -69,6 +69,7 @@
               msg.title,
               msg.arguments,
               msg.description,
+              msg.pre_filled,
             );
             break;
           case "message":

--- a/webui/src/common_types.ts
+++ b/webui/src/common_types.ts
@@ -25,4 +25,5 @@ export type InputDialogConfig = {
   title: string;
   description?: string | undefined;
   input_arguments: InputArg[];
+  pre_filled?: InputValues | null;
 }

--- a/webui/src/lib/InputsDialog.svelte
+++ b/webui/src/lib/InputsDialog.svelte
@@ -7,15 +7,24 @@
     description,
     title,
     input_arguments,
+    pre_filled,
     show = true,
   }: Common.InputDialogConfig & { onsubmit: Common.InputSubmit } = $props();
 
-  let inputs: Common.InputValues = $state({});
+  function pre_filled_args() {
+    return pre_filled || {};
+  }
+
+  let inputs: Common.InputValues = $state(pre_filled_args());
+
+  export function open() {
+    inputs = pre_filled_args();
+    show = true;
+  }
 
   function handle_submit() {
     onsubmit(id, inputs);
     show = false;
-    inputs = {};
   }
 </script>
 

--- a/webui/src/lib/Session.svelte
+++ b/webui/src/lib/Session.svelte
@@ -42,14 +42,17 @@
 
   let entries: SessionEntry[] = $state([]);
 
-  let security_confirm_dialog: Common.SecurityConfirmDialogConfig = $state({
-    show: false,
-    description: "",
-    subject: "",
-    id: "",
-  });
+  let security_confirm_dialog_config: Common.SecurityConfirmDialogConfig =
+    $state({
+      show: false,
+      description: "",
+      subject: "",
+      id: "",
+    });
 
-  let inputs_dialog: Common.InputDialogConfig = $state({
+  let inputs_dialog: InputsDialog;
+
+  let inputs_dialog_config: Common.InputDialogConfig = $state({
     show: false,
     id: "",
     title: "",
@@ -107,10 +110,10 @@
     subject: string,
     id: string,
   ) {
-    security_confirm_dialog.show = true;
-    security_confirm_dialog.description = description;
-    security_confirm_dialog.subject = subject;
-    security_confirm_dialog.id = id;
+    security_confirm_dialog_config.show = true;
+    security_confirm_dialog_config.description = description;
+    security_confirm_dialog_config.subject = subject;
+    security_confirm_dialog_config.id = id;
   }
 
   async function send_confirmation_response(id: string, approved: boolean) {
@@ -122,7 +125,7 @@
   }
 
   function handle_security_confirmation(id: string, approved: boolean) {
-    security_confirm_dialog.show = false;
+    security_confirm_dialog_config.show = false;
     send_confirmation_response(id, approved);
   }
 
@@ -131,12 +134,14 @@
     title: string,
     input_args: Common.InputArg[],
     description?: string | undefined,
+    pre_filled?: Common.InputValues | null,
   ) {
-    inputs_dialog.show = true;
-    inputs_dialog.id = id;
-    inputs_dialog.title = title;
-    inputs_dialog.description = description;
-    inputs_dialog.input_arguments = input_args;
+    inputs_dialog_config.id = id;
+    inputs_dialog_config.title = title;
+    inputs_dialog_config.description = description;
+    inputs_dialog_config.input_arguments = input_args;
+    inputs_dialog_config.pre_filled = pre_filled;
+    inputs_dialog.open();
   }
 
   async function send_inputs_response(id: string, inputs: Common.InputValues) {
@@ -148,7 +153,7 @@
   }
 
   function handle_inputs_submission(id: string, inputs: Common.InputValues) {
-    inputs_dialog.show = false;
+    inputs_dialog_config.show = false;
     send_inputs_response(id, inputs);
   }
 </script>
@@ -194,18 +199,20 @@
 </div>
 
 <SecurityConfirmDialog
-  subject={security_confirm_dialog.subject}
-  description={security_confirm_dialog.description}
-  id={security_confirm_dialog.id}
-  show={security_confirm_dialog.show}
+  subject={security_confirm_dialog_config.subject}
+  description={security_confirm_dialog_config.description}
+  id={security_confirm_dialog_config.id}
+  show={security_confirm_dialog_config.show}
   onconfirm={handle_security_confirmation}
 />
 
 <InputsDialog
-  id={inputs_dialog.id}
-  title={inputs_dialog.title}
-  description={inputs_dialog.description}
-  input_arguments={inputs_dialog.input_arguments}
-  show={inputs_dialog.show}
+  bind:this={inputs_dialog}
+  id={inputs_dialog_config.id}
+  title={inputs_dialog_config.title}
+  description={inputs_dialog_config.description}
+  input_arguments={inputs_dialog_config.input_arguments}
+  pre_filled={inputs_dialog_config.pre_filled}
+  show={inputs_dialog_config.show}
   onsubmit={handle_inputs_submission}
 />


### PR DESCRIPTION
### What?

- Prompts can be invoked with parameters, in which case the user won't be prompted to enter the value for arguments with matching named parameters.
  - E.g. `/prompt use describe lang=Rust` will not prompt user for the `lang` argument
  - In the terminal, the prompt and value are shown but user is not asked.
  - In the web UI, if all arguments have pre-filled values, the dialog window is not shown.

### Why?

- Macros can be invoked with parameters
- With this improvement, a macro can now pass its parameters when invoking a prompt
