### PR TITLE
Add replace lines tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ CLAUDE.md
 .enkaidu
 .deleted_files/
 .spectator-failures
+
+# Ignore temp files created by test suite
+spec/tmp*

--- a/release_notes/v0.9.3-pre.md
+++ b/release_notes/v0.9.3-pre.md
@@ -9,3 +9,4 @@
   - E.g. `/prompt use describe lang=Rust` will not prompt user for the `lang` argument
   - In the terminal, the prompt and value are shown but user is not asked.
   - In the web UI, if all arguments have pre-filled values, the dialog window is not shown.
+- Add a new tool `str_replace_lines_in_text_file` to the `TextEditing` toolset that will replace a range of lines with the given text.

--- a/spec/unit/tools/text_editing/replace_lines_in_text_file_tool_spec.cr
+++ b/spec/unit/tools/text_editing/replace_lines_in_text_file_tool_spec.cr
@@ -1,0 +1,175 @@
+require "../../../spec_helper"
+require "json"
+
+Spectator.describe Tools::TextEditing::ReplaceLinesInTextFileTool do
+  # -----------------------------------------------------------------
+  # Shared test fixtures
+  # -----------------------------------------------------------------
+  let(:temp_dir) { "spec/tmp_test" }
+  let(:file_path) { File.join(temp_dir, "sample.txt") }
+
+  before { Dir.mkdir_p(temp_dir) }
+  after { File.delete?(file_path) }
+
+  let(:runner) { Tools::TextEditing::ReplaceLinesInTextFileTool::Runner.new }
+
+  # -----------------------------------------------------------------
+  # Successful replacement scenarios
+  # -----------------------------------------------------------------
+
+  context "replaces a single line" do
+    let(:content) { "first line old text\nsecond line old text\nthird line" }
+    before { File.write(file_path, content) }
+
+    it "succeeds and reports replacement of one line" do
+      args = {
+        "file_path"  => file_path,
+        "line_range" => [2, 2],
+        "new_str"    => "new line",
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result["error"]?).to be nil
+      expect(result["status"].as_s).to eq "Success"
+      expect(result["message"].as_s).to match(/range.+2[^0-9]+2/)
+
+      # Verify file content after replacement
+      revised_content = File.read(file_path)
+      expect(revised_content).to eq "first line old text\nnew line\nthird line"
+    end
+  end
+
+  context "replaces a range of lines" do
+    let(:content) { "line1\nline2-old\nline3-old\nline4" }
+    before { File.write(file_path, content) }
+
+    it "replaces lines 2 to 3 with new content" do
+      args = {
+        "file_path"  => file_path,
+        "line_range" => [2, 3],
+        "new_str"    => "replaced line A\nreplaced line B",
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result["status"].as_s).to eq "Success"
+      expect(result["message"].as_s).to contain("Successfully replaced")
+      expect(result["message"].as_s).to match(/range.+2[^0-9]+3/)
+
+      revised_content = File.read(file_path)
+      expect(revised_content).to eq "line1\nreplaced line A\nreplaced line B\nline4"
+    end
+  end
+
+  context "replaces all lines when range ends at -1" do
+    let(:content) { "first\nsecond\nthird" }
+    before { File.write(file_path, content) }
+
+    it "replaces all lines with new content" do
+      args = {
+        "file_path"  => file_path,
+        "line_range" => [1, -1],
+        "new_str"    => "NEW ENTIRE FILE",
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result["status"].as_s).to eq "Success"
+      expect(result["message"].as_s).to match(/range.+1[^0-9]+\-1/)
+
+      revised_content = File.read(file_path)
+      expect(revised_content).to eq "NEW ENTIRE FILE"
+    end
+  end
+
+  # -----------------------------------------------------------------
+  # Error handling scenarios
+  # -----------------------------------------------------------------
+
+  context "fails when the target file does not exist" do
+    it "returns an error" do
+      args = {
+        "file_path"  => "nonexistent.txt",
+        "line_range" => [1, 1],
+        "new_str"    => "anything",
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key "error"
+      expect(result["error"].as_s).to contain "does not exist"
+    end
+  end
+
+  context "fails when the line_range is invalid (start > end)" do
+    let(:content) { "only line" }
+    before { File.write(file_path, content) }
+
+    it "returns an error" do
+      args = {
+        "file_path"  => file_path,
+        "line_range" => [3, 2], # start > end
+        "new_str"    => "new",
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key "error"
+      expect(result["error"].as_s).to contain "invalid"
+    end
+  end
+
+  context "fails when line_range contains non-integer values" do
+    let(:content) { "line" }
+    before { File.write(file_path, content) }
+
+    it "returns an error" do
+      args = {
+        "file_path"  => file_path,
+        "line_range" => ["a", "b"], # not integers
+        "new_str"    => "new",
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key "error"
+      expect(result["error"].as_s).to contain "must be an array with two integers"
+    end
+  end
+
+  context "fails when the specified file is outside the current directory" do
+    let(:file_path) { File.tempname("_outside.txt") }
+
+    it "returns an error" do
+      args = {
+        "file_path"  => file_path,
+        "line_range" => [1, 1],
+        "new_str"    => "new",
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key "error"
+      expect(result["error"].as_s).to contain "not allowed"
+    end
+  end
+
+  context "fails when `new_str` is not provided" do
+    let(:content) { "line1\nline2" }
+    before { File.write(file_path, content) }
+
+    it "returns an error" do
+      args = {
+        "file_path"  => file_path,
+        "line_range" => [1, 2],
+        "new_str"    => nil,
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key "error"
+      expect(result["error"].as_s).to contain "not specified"
+    end
+  end
+end

--- a/spec/unit/tools/text_editing/str_replace_in_text_file_tool_spec.cr
+++ b/spec/unit/tools/text_editing/str_replace_in_text_file_tool_spec.cr
@@ -1,0 +1,107 @@
+require "../../../spec_helper"
+require "json"
+
+Spectator.describe Tools::TextEditing::ReplaceTextInTextFileTool do
+  # -----------------------------------------------------------------
+  # Shared test fixtures
+  # -----------------------------------------------------------------
+  let(:temp_dir) { "spec/tmp_test" }
+  let(:file_path) { File.join(temp_dir, "sample.txt") }
+
+  before { Dir.mkdir_p(temp_dir) }
+  after { File.delete?(file_path) }
+
+  let(:runner) { Tools::TextEditing::ReplaceTextInTextFileTool::Runner.new }
+
+  # -----------------------------------------------------------------
+  # Successful replacement scenarios
+  # -----------------------------------------------------------------
+  context "replaces the first occurrence when `multiple` is false" do
+    let(:content) { "first line old text second line old text" }
+    before { File.write(file_path, content) }
+
+    it "succeeds and reports a single replacement" do
+      result_json = runner.execute(JSON.parse({
+        "file_path" => file_path,
+        "old_str"   => "old",
+        "new_str"   => "new",
+        "multiple"  => false,
+      }.to_json))
+      result = JSON.parse(result_json)
+
+      expect(result["replacements"].as_i).to be 1
+      expect(result["new_content"].as_s).to eq "first line new text second line old text"
+    end
+  end
+
+  context "replaces all occurrences when `multiple` is true" do
+    let(:content) { "first line old text second line old text" }
+    before { File.write(file_path, content) }
+
+    it "succeeds and reports multiple replacements" do
+      result_json = runner.execute(JSON.parse({
+        "file_path" => file_path,
+        "old_str"   => "old",
+        "new_str"   => "new",
+        "multiple"  => true,
+      }.to_json))
+      result = JSON.parse(result_json)
+
+      expect(result["replacements"].as_i).to be 2
+      expect(result["new_content"].as_s).to eq "first line new text second line new text"
+    end
+  end
+
+  # -----------------------------------------------------------------
+  # Error handling scenarios
+  # -----------------------------------------------------------------
+  context "fails when the target file does not exist" do
+    it "returns an error" do
+      result_json = runner.execute(JSON.parse({
+        "file_path" => "nonexistent.txt",
+        "old_str"   => "any",
+        "new_str"   => "thing",
+        "multiple"  => false,
+      }.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key "error"
+      expect(result["error"].as_s).to contain "does not exist"
+    end
+  end
+
+  context "fails when the old string is not found" do
+    let(:content) { "no old here" }
+    before { File.write(file_path, content) }
+
+    it "returns an error" do
+      result_json = runner.execute(JSON.parse({
+        "file_path" => file_path,
+        "old_str"   => "missing",
+        "new_str"   => "something",
+        "multiple"  => false,
+      }.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key "error"
+      expect(result["error"].as_s).to contain "Unable to find old string"
+    end
+  end
+
+  context "rejects paths outside the current directory" do
+    let(:file_path) { File.tempname("_outside.txt") }
+
+    it "returns an error" do
+      result_json = runner.execute(JSON.parse({
+        "file_path" => file_path,
+        "old_str"   => "test",
+        "new_str"   => "changed",
+        "multiple"  => false,
+      }.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key "error"
+      expect(result["error"].as_s).to contain "not allowed"
+    end
+  end
+end

--- a/src/tools/toolsets/text_editing.cr
+++ b/src/tools/toolsets/text_editing.cr
@@ -8,6 +8,7 @@ module Tools
       hold WriteTextFileTool
       hold ReplaceTextInTextFileTool
       hold InsertLinesInTextFileTool
+      hold ReplaceLinesInTextFileTool
     end
     Tools.register(toolset)
   end

--- a/src/tools/toolsets/text_editing/replace_lines_in_text_file.cr
+++ b/src/tools/toolsets/text_editing/replace_lines_in_text_file.cr
@@ -76,12 +76,17 @@ module Tools::TextEditing
             line_no += 1
             if line_no < start_line
               io << line
-            elsif line_no == start_line
-              # skip, and insert replacement
-              io.puts(new_str)
+            elsif line_no == start_line && end_line.negative?
+              io << new_str
               replaced = true
-              # Short-circuit reading loop if we're replacing to end of file
-              break if end_line.negative?
+              break # short-circuit reading loop
+            elsif line_no == end_line
+              # if we get here, we're at last line to range to replace
+              # and we're NOT replacing to end of file
+              io << new_str
+              # If line has newline, give it back
+              io.puts if line.chomp.size < line.size
+              replaced = true
             elsif line_no > end_line
               io << line
             end

--- a/src/tools/toolsets/text_editing/replace_lines_in_text_file.cr
+++ b/src/tools/toolsets/text_editing/replace_lines_in_text_file.cr
@@ -28,74 +28,70 @@ module Tools::TextEditing
       def execute(args : JSON::Any) : String
         file_path = args["file_path"]?.try &.as_s? ||
                     return error_response("The required `file_path` was not specified")
-        line_range = if range = args["line_range"]?
-                       if (arr = range.as_a?) && arr.size == 2 && (line_start = arr[0]?.try(&.as_i?)) && (line_end = arr[1]?.try(&.as_i?))
-                         if line_start >= 0 && (line_end.negative? || line_start <= line_end)
-                           [line_start, line_end]
-                         else
-                           return error_response("The `line_range` is invalid: start line (#{line_start}) > end line (#{line_end})")
-                         end
-                       else
-                         return error_response("The `line_range` must be an array with two integers.")
-                       end
-                     else
-                       return error_response("The required `line_range` was not specified")
-                     end
         new_str = args["new_str"]?.try &.as_s? ||
                   return error_response("The required `new_str` was not specified")
-
         resolved_path = resolve_path(file_path)
 
         return error_response("The specified path '#{file_path}' is not allowed.") unless within_current_directory?(resolved_path)
         return error_response("The specified file '#{file_path}' does not exist or is not a file.") unless valid_file?(resolved_path)
 
         begin
-          inserted = false
-          new_content = String.build do |io|
-            line_no = 0
-            start_line = line_range.first
-            end_line = line_range.last
+          line_range = parse_line_range(args["line_range"]?)
 
-            File.each_line(resolved_path, chomp: false) do |line|
-              line_no += 1
-              if line_no < start_line
-                io << line
-              elsif line_no == start_line
-                # skip, and insert replacement
-                io.puts(new_str)
-                inserted = true
-                # Short-circuit reading loop if we're replacing to end of file
-                break if end_line.negative?
-              elsif line_no > end_line
-                io << line
-              end
-            end
-          end
-          if inserted
-            # Changes made
+          if new_content = replace_lines(resolved_path, line_range, new_str)
             File.write(resolved_path, new_content)
             success_response(file_path, "Successfully replaced lines in the range #{line_range} in the text file.")
           else
-            error_response("Insertion failed, file hass less lines that #{line_range.first}. File not modified. ")
+            error_response("Replacement failed, file hass less lines that #{line_range.first}. File not modified. ")
           end
         rescue e
-          error_response("An error occurred while modifying the file: #{e.message}")
+          error_response(e.message)
         end
+      end
+
+      private def parse_line_range(range)
+        if range
+          if (arr = range.as_a?) && arr.size == 2 && (line_start = arr[0]?.try(&.as_i?)) && (line_end = arr[1]?.try(&.as_i?))
+            if line_start >= 0 && (line_end.negative? || line_start <= line_end)
+              [line_start, line_end]
+            else
+              raise Exception.new("The `line_range` is invalid: start line (#{line_start}) > end line (#{line_end})")
+            end
+          else
+            raise Exception.new("The `line_range` must be an array with two integers.")
+          end
+        else
+          raise Exception.new("The required `line_range` was not specified")
+        end
+      end
+
+      private def replace_lines(resolved_path, line_range, new_str) : String?
+        replaced = false
+        new_content = String.build do |io|
+          line_no = 0
+          start_line = line_range.first
+          end_line = line_range.last
+
+          File.each_line(resolved_path, chomp: false) do |line|
+            line_no += 1
+            if line_no < start_line
+              io << line
+            elsif line_no == start_line
+              # skip, and insert replacement
+              io.puts(new_str)
+              replaced = true
+              # Short-circuit reading loop if we're replacing to end of file
+              break if end_line.negative?
+            elsif line_no > end_line
+              io << line
+            end
+          end
+        end
+        replaced ? new_content : nil
       end
 
       private def error_response(message)
         {"error" => message}.to_json
-      end
-
-      private def with_line_numbers(content)
-        String.build do |io|
-          line_no = 0
-          content.each_line(chomp: false) do |line|
-            line_no += 1
-            io.printf("%6d\t", line_no)
-            io << line
-          end
-        end
       end
 
       private def success_response(file_path, message)

--- a/src/tools/toolsets/text_editing/replace_lines_in_text_file.cr
+++ b/src/tools/toolsets/text_editing/replace_lines_in_text_file.cr
@@ -1,0 +1,106 @@
+require "json"
+require "../../built_in_function"
+require "../../file_helper"
+
+module Tools::TextEditing
+  # The `InsertLinesInTextFileTool` class defines a tool for inserting text at
+  # a specific line in a text file. It ensures the operation is performed securely within the
+  # allowed directory, avoiding access to unauthorized paths.
+  class ReplaceLinesInTextFileTool < BuiltInFunction
+    name "str_replace_lines_in_text_file"
+
+    description "Replace a range of lines in a text file within the current directory with given text."
+
+    param "file_path", type: Param::Type::Str,
+      description: "The relative path to the text file to modify.", required: true
+    param "line_range", type: Param::Type::Arr, required: true,
+      description: "An array of two integers specifying the start and end line numbers." \
+                   "Line numbers are 1-indexed, and -1 for the end line means read to the end of the file."
+    param "new_str", type: Param::Type::Num,
+      description: "The new text to insert in place of the replaced lines.", required: true
+
+    runner Runner
+
+    # The Runner class executes the function
+    class Runner < LLM::Function::Runner
+      include FileHelper
+
+      def execute(args : JSON::Any) : String
+        file_path = args["file_path"]?.try &.as_s? ||
+                    return error_response("The required `file_path` was not specified")
+        line_range = if range = args["line_range"]?
+                       if (arr = range.as_a?) && arr.size == 2 && (line_start = arr[0]?.try(&.as_i?)) && (line_end = arr[1]?.try(&.as_i?))
+                         if line_start >= 0 && (line_end.negative? || line_start <= line_end)
+                           [line_start, line_end]
+                         else
+                           return error_response("The `line_range` is invalid: start line (#{line_start}) > end line (#{line_end})")
+                         end
+                       else
+                         return error_response("The `line_range` must be an array with two integers.")
+                       end
+                     else
+                       return error_response("The required `line_range` was not specified")
+                     end
+        new_str = args["new_str"]?.try &.as_s? ||
+                  return error_response("The required `new_str` was not specified")
+
+        resolved_path = resolve_path(file_path)
+
+        return error_response("The specified path '#{file_path}' is not allowed.") unless within_current_directory?(resolved_path)
+        return error_response("The specified file '#{file_path}' does not exist or is not a file.") unless valid_file?(resolved_path)
+
+        begin
+          inserted = false
+          new_content = String.build do |io|
+            line_no = 0
+            start_line = line_range.first
+            end_line = line_range.last
+
+            File.each_line(resolved_path, chomp: false) do |line|
+              line_no += 1
+              if line_no < start_line
+                io << line
+              elsif line_no == start_line
+                # skip, and insert replacement
+                io.puts(new_str)
+                inserted = true
+                # Short-circuit reading loop if we're replacing to end of file
+                break if end_line.negative?
+              elsif line_no > end_line
+                io << line
+              end
+            end
+          end
+          if inserted
+            # Changes made
+            File.write(resolved_path, new_content)
+            success_response(file_path, "Successfully replaced lines in the range #{line_range} in the text file.")
+          else
+            error_response("Insertion failed, file hass less lines that #{line_range.first}. File not modified. ")
+          end
+        rescue e
+          error_response("An error occurred while modifying the file: #{e.message}")
+        end
+      end
+
+      private def error_response(message)
+        {"error" => message}.to_json
+      end
+
+      private def with_line_numbers(content)
+        String.build do |io|
+          line_no = 0
+          content.each_line(chomp: false) do |line|
+            line_no += 1
+            io.printf("%6d\t", line_no)
+            io << line
+          end
+        end
+      end
+
+      private def success_response(file_path, message)
+        {file_path: file_path, status: "Success", message: message}.to_json
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What?

- Add a new tool `str_replace_lines_in_text_file` to the `TextEditing` toolset that will replace a range of lines with the given text.

### Why?

SInce we have a tool that can return text files with line numbers, this tool could help LLMs perform more surgical replacements that trying to find and replace text, especially when text is hard to replace. 