### PR TITLE
Support auto-completion prompt argument input

### DIFF
--- a/release_notes/v0.9.3-pre.md
+++ b/release_notes/v0.9.3-pre.md
@@ -10,3 +10,4 @@
   - In the terminal, the prompt and value are shown but user is not asked.
   - In the web UI, if all arguments have pre-filled values, the dialog window is not shown.
 - Add a new tool `str_replace_lines_in_text_file` to the `TextEditing` toolset that will replace a range of lines with the given text.
+- Support `Tab` auto-completion for paths/files for prompt argument inputs in terminal

--- a/src/enkaidu/console/input_reader.cr
+++ b/src/enkaidu/console/input_reader.cr
@@ -4,14 +4,52 @@ require "colorize"
 module Enkaidu::Console
   class InputReader < Reply::Reader
     property label : String
+    private getter styler : Console::StyleApplicator
 
-    def initialize(@label)
+    DELIMETERS = {{" \n\t'\"=".chars}}
+
+    def initialize(@label, @styler)
       super()
+      editor.word_delimiters = DELIMETERS
     end
 
     def prompt(io : IO, line_number : Int32, color : Bool) : Nil
       q = label.colorize(:cyan) if color
       io << q
+    end
+
+    # Override to integrate auto-completion.
+    #
+    # *current_word* is picked following `word_delimiters`.
+    # It expects to return `Tuple` with:
+    # * a title : `String`
+    # * the auto-completion results : `Array(String)`
+    #
+    # default: `{"", [] of String}`
+    def auto_complete(current_word : String, expression_before : String)
+      if current_word.starts_with?("./")
+        # Tab completion for paths in current folder
+        if current_word.size > 2 && Path::SEPARATORS.includes?(current_word[-1])
+          current_word = current_word[0..-2]
+        end
+        path = Path.new(current_word)
+        path = path.parent unless File.directory?(path)
+        {
+          "Files and Folders",
+          Dir.new(path).children.map { |name| (path / name).to_s },
+        }
+      else
+        # Nothing to complete
+        {"", [] of String}
+      end
+    end
+
+    # Highlight the expression
+    def highlight(expression : String) : String
+      # Paths that start with `./`
+      expression.gsub(/\.(\/[^\s]+)+\/?/) do |match|
+        styler.fmt(:query_syntax_path, match)
+      end
     end
   end
 end

--- a/src/enkaidu/console/renderer.cr
+++ b/src/enkaidu/console/renderer.cr
@@ -14,6 +14,11 @@ module Enkaidu::Console
     property? streaming = false
     property? quiet = false
 
+    # Internal input for prompt args
+    private def input
+      @input ||= InputReader.new("> ", styler: self)
+    end
+
     private macro mdr_heading_style(prefix = "", underline = false)
       {
         bold: true,
@@ -58,8 +63,6 @@ module Enkaidu::Console
         end
       end
     end
-
-    private getter input = InputReader.new("> ")
 
     private def prepare_text(help, markdown)
       markdown ? markdown_to_term(help.to_s) : help


### PR DESCRIPTION
### What?

Support `Tab` auto-completion for paths/files for prompt argument inputs in terminal

### Why?

Prompts often want files to specified as arguments. 