### PR TITLE
Add unit tests for supported / built-in tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Install shards
         if: ${{ runner.os != 'Linux' }}
-        run: shards check || shards install --production
+        run: shards check --production || shards install --production
 
       # Non-Windows
       - name: Setup release environment
@@ -89,7 +89,7 @@ jobs:
 
       - name: Build Release
         if: ${{ runner.os != 'Windows' }}
-        run: SHARDS_BIN_PATH=bin/release shards build --production
+        run: SHARDS_BIN_PATH=bin/release shards build --release
 
       # Ah, Windows.
       - name: Setup release environment (Windows)
@@ -105,4 +105,4 @@ jobs:
         env:
           SHARDS_BIN_PATH: "bin/release"
         run: |
-          shards build --production
+          shards build --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build-and-test:
@@ -43,9 +43,6 @@ jobs:
             bin/ameba
           key: ${{ runner.os }}-shards-${{ hashFiles('**/shard.lock') }}
 
-      - name: Install shards
-        run: shards check || shards install
-
       - name: Prepare and build webui
         run: |
           cd webui
@@ -54,6 +51,10 @@ jobs:
           cd ..
 
       # ---- Build debug release and check code quality on one platform
+
+      - name: Install shards
+        if: ${{ runner.os == 'Linux' }}
+        run: shards check || shards install
 
       - name: Setup debug environment (Linux)
         if: ${{ runner.os == 'Linux' }}
@@ -77,6 +78,10 @@ jobs:
 
       # ---- Build releases on all platforms
 
+      - name: Install shards
+        if: ${{ runner.os != 'Linux' }}
+        run: shards check || shards install --production
+
       # Non-Windows
       - name: Setup release environment
         if: ${{ runner.os != 'Windows' }}
@@ -84,7 +89,7 @@ jobs:
 
       - name: Build Release
         if: ${{ runner.os != 'Windows' }}
-        run: SHARDS_BIN_PATH=bin/release shards build --release
+        run: SHARDS_BIN_PATH=bin/release shards build --production
 
       # Ah, Windows.
       - name: Setup release environment (Windows)
@@ -100,4 +105,4 @@ jobs:
         env:
           SHARDS_BIN_PATH: "bin/release"
         run: |
-          shards build --release
+          shards build --production

--- a/ops.yml
+++ b/ops.yml
@@ -15,7 +15,7 @@ actions:
     description: Build the Svelte-based web UI
     alias: bwui
   build-release:
-    command: ops build-webui && SHARDS_BIN_PATH=bin/release shards build $APP --production
+    command: ops build-webui && SHARDS_BIN_PATH=bin/release shards build $APP --release
     description: Build for release
     alias: br
   build-debug:

--- a/ops.yml
+++ b/ops.yml
@@ -15,7 +15,7 @@ actions:
     description: Build the Svelte-based web UI
     alias: bwui
   build-release:
-    command: ops build-webui && SHARDS_BIN_PATH=bin/release shards build $APP --release
+    command: ops build-webui && SHARDS_BIN_PATH=bin/release shards build $APP --production
     description: Build for release
     alias: br
   build-debug:
@@ -23,7 +23,6 @@ actions:
     description: Build for development (debugging)
     aliases: [build, bd]
   install:
-    quiet: true
     description: Build a release and copy it into the '$INSTALL_DIR' folder with version appended.
     command: |
       BRANCH=$(git branch --show-current)

--- a/release_notes/v0.9.4-pre.md
+++ b/release_notes/v0.9.4-pre.md
@@ -1,0 +1,8 @@
+
+#### FIXES
+
+- Fixed the `str_replace_in_text_file`, `str_replace_lines_in_text_file`, `str_insert_in_text_file`, and `str_regex_replace_in_text_file` (also renamed) tools to not allow edits to file in the `.deleted_files/` folder.
+
+#### MISCELLANEOUS
+
+- Added unit tests for a number of tools

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: enkaidu
-version: 0.9.3
+version: 0.9.4-pre
 license: MPL-2.0
 description: Command line tool that can use local and remote AI models to assist
   with local editing and refinement tasks.

--- a/spec/unit/tools/date_and_time/get_current_datetime_tool_spec.cr
+++ b/spec/unit/tools/date_and_time/get_current_datetime_tool_spec.cr
@@ -1,0 +1,113 @@
+require "../../../spec_helper"
+
+Spectator.describe Tools::DateAndTime::GetCurrentDatetimeTool do
+  let(:runner) { Tools::DateAndTime::GetCurrentDatetimeTool::Runner.new }
+
+  # Helper to parse the JSON result from execute
+  def parse_result(result_json)
+    JSON.parse(result_json).as_h
+  end
+
+  context "when execute is called" do
+    it "returns a valid JSON string" do
+      args = {} of String => JSON::Any
+      result_json = runner.execute(JSON.parse(args.to_json))
+      parsed = parse_result(result_json)
+
+      expect(parsed).to be_a(Hash(String, JSON::Any))
+    end
+
+    it "contains a current_datetime field" do
+      args = {} of String => JSON::Any
+      result_json = runner.execute(JSON.parse(args.to_json))
+      parsed = parse_result(result_json)
+
+      expect(parsed).to have_key("current_datetime")
+    end
+
+    it "current_datetime is a non-empty string" do
+      args = {} of String => JSON::Any
+      result_json = runner.execute(JSON.parse(args.to_json))
+      parsed = parse_result(result_json)
+
+      datetime_str = parsed["current_datetime"].as_s
+      expect(datetime_str).to_not be_empty
+      expect(datetime_str).to be_a(String)
+    end
+  end
+
+  context "when validating ISO 8601 format" do
+    it "current_datetime matches ISO 8601 pattern with timezone offset" do
+      args = {} of String => JSON::Any
+      result_json = runner.execute(JSON.parse(args.to_json))
+      parsed = parse_result(result_json)
+
+      datetime_str = parsed["current_datetime"].as_s
+      # ISO 8601 format: YYYY-MM-DDTHH:MM:SS+HH:MM or YYYY-MM-DDTHH:MM:SSZ
+      iso_format = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}/
+      expect(datetime_str).to match(iso_format)
+    end
+
+    it "current_datetime has correct date components" do
+      args = {} of String => JSON::Any
+      result_json = runner.execute(JSON.parse(args.to_json))
+      parsed = parse_result(result_json)
+
+      datetime_str = parsed["current_datetime"].as_s
+      # Extract just the date part
+      date_parts = datetime_str.split("T").first.split("-")
+      year = date_parts[0].to_i
+      month = date_parts[1].to_i
+      day = date_parts[2].to_i
+
+      expect(datetime_str.split("T").first.size).to eq(10)
+      expect(datetime_str.split("T")[1].split(":").size).to eq(4)
+      expect(year).to be_gt(2000)
+      expect(month).to be_between(1, 12)
+      expect(day).to be_between(1, 31)
+    end
+  end
+
+  context "when validating timezone offset" do
+    it "contains a +00:00 offset indicating UTC" do
+      args = {} of String => JSON::Any
+      result_json = runner.execute(JSON.parse(args.to_json))
+      parsed = parse_result(result_json)
+
+      datetime_str = parsed["current_datetime"].as_s
+      expect(datetime_str).to end_with("+00:00")
+    end
+  end
+
+  context "when called with a reason parameter" do
+    it "still returns correct datetime" do
+      args = {"reason" => JSON.parse(%("test reason"))}
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      parsed = parse_result(result_json)
+
+      datetime_str = parsed["current_datetime"].as_s
+      expect(datetime_str).to_not be_empty
+      expect(datetime_str).to end_with("+00:00")
+    end
+  end
+
+  context "when called multiple times" do
+    it "returns different timestamps" do
+      args = {} of String => JSON::Any
+
+      result_json1 = runner.execute(JSON.parse(args.to_json))
+      parsed1 = parse_result(result_json1)
+      time1 = Time.parse(parsed1["current_datetime"].as_s, "%FT%T%:z", Time::Location.local)
+
+      # Small sleep to ensure time difference
+      sleep 1.millisecond
+
+      result_json2 = runner.execute(JSON.parse(args.to_json))
+      parsed2 = parse_result(result_json2)
+      time2 = Time.parse(parsed2["current_datetime"].as_s, "%FT%T%:z", Time::Location.local)
+
+      expect(time2).to be_ge(time1)
+    end
+  end
+end

--- a/spec/unit/tools/experimental/regex_edit_tool_spec.cr
+++ b/spec/unit/tools/experimental/regex_edit_tool_spec.cr
@@ -263,20 +263,16 @@ Spectator.describe Tools::Experimental::RegexTextEditTool do
   # Missing parameter errors
   # -------------------------------------------------
   context "fails when file_path is not specified" do
-    before { File.write(abs_file_path, "hello") }
-
     it "returns an error mentioning file_path" do
-      Dir.cd(temp_dir) do
-        args = {
-          "pattern"   => "foo",
-          "new_str"   => "bar",
-        }
-        result_json = runner.execute(JSON.parse(args.to_json))
-        result = parse_run_result(result_json)
+      args = {
+        "pattern" => "foo",
+        "new_str" => "bar",
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
 
-        expect(result[:success]).to be_false
-        expect(result[:error_msg]).to contain("file_path")
-      end
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).to contain("file_path")
     end
   end
 
@@ -284,17 +280,15 @@ Spectator.describe Tools::Experimental::RegexTextEditTool do
     before { File.write(abs_file_path, "hello") }
 
     it "returns an error mentioning pattern" do
-      Dir.cd(temp_dir) do
-        args = {
-          "file_path" => "sample.txt",
-          "new_str"   => "world",
-        }
-        result_json = runner.execute(JSON.parse(args.to_json))
-        result = parse_run_result(result_json)
+      args = {
+        "file_path" => "sample.txt",
+        "new_str"   => "world",
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
 
-        expect(result[:success]).to be_false
-        expect(result[:error_msg]).to contain("pattern")
-      end
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).to contain("pattern")
     end
   end
 
@@ -302,17 +296,15 @@ Spectator.describe Tools::Experimental::RegexTextEditTool do
     before { File.write(abs_file_path, "hello") }
 
     it "returns an error mentioning new_str" do
-      Dir.cd(temp_dir) do
-        args = {
-          "file_path" => "sample.txt",
-          "pattern"   => "hello",
-        }
-        result_json = runner.execute(JSON.parse(args.to_json))
-        result = parse_run_result(result_json)
+      args = {
+        "file_path" => "sample.txt",
+        "pattern"   => "hello",
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
 
-        expect(result[:success]).to be_false
-        expect(result[:error_msg]).to contain("new_str")
-      end
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).to contain("new_str")
     end
   end
 
@@ -321,58 +313,52 @@ Spectator.describe Tools::Experimental::RegexTextEditTool do
   # -------------------------------------------------
   context "fails when the specified file does not exist" do
     it "returns an error mentioning the file does not exist" do
-      Dir.cd(temp_dir) do
-        args = {
-          "file_path" => "nonexistent.txt",
-          "pattern"   => "foo",
-          "new_str"   => "bar",
-        }
-        result_json = runner.execute(JSON.parse(args.to_json))
-        result = parse_run_result(result_json)
+      args = {
+        "file_path" => "nonexistent.txt",
+        "pattern"   => "foo",
+        "new_str"   => "bar",
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
 
-        expect(result[:success]).to be_false
-        expect(result[:error_msg]).to contain("does not exist")
-      end
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).to contain("does not exist")
     end
   end
 
   context "fails when the regex matches nothing in the file" do
     let(:content) { "nothing matches this pattern" }
-    before { File.write(file_path, content) }
+    before { File.write(abs_file_path, content) }
 
     it "returns an error about no strings being found" do
-      Dir.cd(temp_dir) do
-        args = {
-          "file_path" => file_path,
-          "pattern"   => "xyzxyzxyz",
-          "new_str"   => "replacement",
-        }
-        result_json = runner.execute(JSON.parse(args.to_json))
-        result = parse_run_result(result_json)
+      args = {
+        "file_path" => abs_file_path,
+        "pattern"   => "xyzxyzxyz",
+        "new_str"   => "replacement",
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
 
-        expect(result[:success]).to be_false
-        expect(result[:error_msg]).to contain("Unable to find")
-      end
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).to contain("Unable to find")
     end
   end
 
   context "fails when regex is invalid" do
     let(:content) { "some text" }
-    before { File.write(file_path, content) }
+    before { File.write(abs_file_path, content) }
 
     it "returns an error for malformed regex" do
-      Dir.cd(temp_dir) do
-        args = {
-          "file_path" => file_path,
-          "pattern"   => "[invalid",
-          "new_str"   => "replaced",
-        }
-        result_json = runner.execute(JSON.parse(args.to_json))
-        result = parse_run_result(result_json)
+      args = {
+        "file_path" => abs_file_path,
+        "pattern"   => "[invalid",
+        "new_str"   => "replaced",
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
 
-        expect(result[:success]).to be_false
-        expect(result[:error_msg]).to contain("error")
-      end
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).to contain("Invalid")
     end
   end
 
@@ -380,42 +366,38 @@ Spectator.describe Tools::Experimental::RegexTextEditTool do
   # Security scenarios
   # -------------------------------------------------
   context "blocks paths resolved outside the current directory" do
-    let(:outside_path) { File.expand_path("/tmp/outside_test_file") }
+    let(:outside_path) { File.tempname("_outside.txt") }
 
     after { File.delete?(outside_path) }
 
     it "returns an error indicating the path is not allowed" do
       File.write(outside_path, "some content")
 
-      Dir.cd(temp_dir) do
-        args = {
-          "file_path" => "../tmp/outside_test_file",
-          "pattern"   => "foo",
-          "new_str"   => "bar",
-        }
-        result_json = runner.execute(JSON.parse(args.to_json))
-        result = parse_run_result(result_json)
+      args = {
+        "file_path" => outside_path,
+        "pattern"   => "foo",
+        "new_str"   => "bar",
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
 
-        expect(result[:success]).to be_false
-        expect(result[:error_msg]).to contain("not allowed")
-      end
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).to contain("not allowed")
     end
   end
 
   context "blocks multiple ../ sequences in the path" do
     it "returns an error for deeply nested path traversal" do
-      Dir.cd(temp_dir) do
-        args = {
-          "file_path" => "deep/../../../etc/passwd",
-          "pattern"   => "foo",
-          "new_str"   => "bar",
-        }
-        result_json = runner.execute(JSON.parse(args.to_json))
-        result = parse_run_result(result_json)
+      args = {
+        "file_path" => "deep/../../../etc/passwd",
+        "pattern"   => "foo",
+        "new_str"   => "bar",
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
 
-        expect(result[:success]).to be_false
-        expect(result[:error_msg]).to contain("not allowed")
-      end
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).to contain("not allowed")
     end
   end
 end

--- a/spec/unit/tools/experimental/regex_edit_tool_spec.cr
+++ b/spec/unit/tools/experimental/regex_edit_tool_spec.cr
@@ -1,0 +1,421 @@
+require "../../../spec_helper"
+require "json"
+
+Spectator.describe Tools::Experimental::RegexTextEditTool do
+  # -------------------------------------------------
+  # Shared test fixtures
+  # -------------------------------------------------
+  let(:temp_dir) { File.expand_path("spec/tmp_regex_test") }
+  let(:file_path) { "sample.txt" }
+  let(:abs_file_path) { File.join(temp_dir, "sample.txt") }
+  let(:runner) { Tools::Experimental::RegexTextEditTool::Runner.new }
+
+  # Recursively delete a directory for cleanup
+  def rm_rf(path)
+    return unless path.starts_with?(temp_dir)
+    if Dir.exists?(path)
+      Dir.each_child(path) do |entry|
+        full = File.join(path, entry)
+        if Dir.exists?(full)
+          rm_rf(full)
+        else
+          File.delete?(full)
+        end
+      end
+      Dir.delete?(path)
+    end
+  end
+
+  before { Dir.mkdir_p(temp_dir) }
+  after { rm_rf(temp_dir) if Dir.exists?(temp_dir) }
+
+  # -------------------------------------------------
+  # Helper methods
+  # -------------------------------------------------
+  def parse_run_result(result_json)
+    parsed = JSON.parse(result_json)
+    hash_val = parsed.as_h?
+    if hash_val
+      err = hash_val["error"]?
+      if err
+        return {success: false, data: parsed, error_msg: err.as_s}
+      end
+    end
+    {success: true, data: parsed, error_msg: nil}
+  end
+
+  # -------------------------------------------------
+  # Successful replacement scenarios
+  # -------------------------------------------------
+  context "replaces a single match" do
+    let(:content) { "hello world" }
+    before { File.write(abs_file_path, content) }
+
+    it "succeeds and returns correct replacement count and new content" do
+      args = {
+        "file_path" => "sample.txt",
+        "pattern"   => "world",
+        "new_str"   => "universe",
+      }
+      Dir.cd(temp_dir) do
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(result[:error_msg]).to be_nil
+        expect(result[:data]["replacements"].as_i).to be 1
+        expect(result[:data]["new_content"].as_s).to eq("hello universe")
+        expect(result[:data]["file_path"].as_s).to eq("sample.txt")
+      end
+    end
+  end
+
+  context "replaces multiple matches across the file" do
+    let(:content) { "foo bar foo baz foo" }
+    before { File.write(abs_file_path, content) }
+
+    it "replaces all occurrences and reports correct count" do
+      args = {
+        "file_path" => "sample.txt",
+        "pattern"   => "foo",
+        "new_str"   => "qux",
+      }
+      Dir.cd(temp_dir) do
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(result[:data]["replacements"].as_i).to be 3
+        expect(result[:data]["new_content"].as_s).to eq("qux bar qux baz qux")
+      end
+    end
+  end
+
+  context "replaces across multiple lines with multiline regex" do
+    let(:content) { "line one\ntwo\nline three\nfour\n" }
+    before { File.write(abs_file_path, content) }
+
+    it "matches word boundaries with /m flag" do
+      args = {
+        "file_path" => "sample.txt",
+        "pattern"   => "(?m)^line ",
+        "new_str"   => ">>> ",
+      }
+      Dir.cd(temp_dir) do
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(result[:data]["replacements"].as_i).to be 2
+        expect(result[:data]["new_content"].as_s).to eq(">>> one\ntwo\n>>> three\nfour\n")
+      end
+    end
+  end
+
+  context "handles captured groups in patterns" do
+    let(:content) { "hello world hello" }
+    before { File.write(abs_file_path, content) }
+
+    it "matches the full pattern with capture groups" do
+      args = {
+        "file_path" => "sample.txt",
+        "pattern"   => "(hello) (world)",
+        "new_str"   => "WORLD HELLO",
+      }
+      Dir.cd(temp_dir) do
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(result[:data]["replacements"].as_i).to be 1
+        expect(result[:data]["new_content"].as_s).to eq("WORLD HELLO hello")
+      end
+    end
+  end
+
+  context "replaces regex metacharacters in pattern" do
+    let(:content) { "price: $10, price: $20, price: $30" }
+    before { File.write(abs_file_path, content) }
+
+    it "handles dollar sign escaped in literal replacement context" do
+      args = {
+        "file_path" => "sample.txt",
+        "pattern"   => "\\$\\d+",
+        "new_str"   => "N/A",
+      }
+      Dir.cd(temp_dir) do
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(result[:data]["replacements"].as_i).to be 3
+        expect(result[:data]["new_content"].as_s).to eq("price: N/A, price: N/A, price: N/A")
+      end
+    end
+  end
+
+  context "replaces to an empty string" do
+    let(:content) { "abc 123 def 456 ghi" }
+    before { File.write(abs_file_path, content) }
+
+    it "removes all matching digit sequences" do
+      args = {
+        "file_path" => "sample.txt",
+        "pattern"   => "\\d+",
+        "new_str"   => "",
+      }
+      Dir.cd(temp_dir) do
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(result[:data]["replacements"].as_i).to be 2
+        expect(result[:data]["new_content"].as_s).to eq("abc  def  ghi")
+      end
+    end
+  end
+
+  context "handles unicode content in the file" do
+    let(:content) { "cafe\u0301 cafe\u0301 cafe\u0301\n" }
+    before { File.write(abs_file_path, content) }
+
+    it "matches unicode characters correctly" do
+      args = {
+        "file_path" => "sample.txt",
+        "pattern"   => "cafe\u0301",
+        "new_str"   => "cafe",
+      }
+      Dir.cd(temp_dir) do
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(result[:data]["replacements"].as_i).to be 3
+        expect(result[:data]["new_content"].as_s).to eq("cafe cafe cafe\n")
+      end
+    end
+  end
+
+  context "handles unicode patterns matched by word chars" do
+    let(:content) { "a1 b2 c3\n" }
+    before { File.write(abs_file_path, content) }
+
+    it "matches word characters across newlines" do
+      args = {
+        "file_path" => "sample.txt",
+        "pattern"   => "(?m)(\\w)(\\d)",
+        "new_str"   => "X",
+      }
+      Dir.cd(temp_dir) do
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(result[:data]["replacements"].as_i).to be 3
+        expect(result[:data]["new_content"].as_s).to eq("X X X\n")
+      end
+    end
+  end
+
+  context "handles a single-line file" do
+    let(:content) { "single line with MATCH to replace" }
+    before { File.write(abs_file_path, content) }
+
+    it "replaces the match on the single line" do
+      args = {
+        "file_path" => "sample.txt",
+        "pattern"   => "MATCH",
+        "new_str"   => "RESULT",
+      }
+      Dir.cd(temp_dir) do
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(result[:data]["replacements"].as_i).to be 1
+        expect(result[:data]["new_content"].as_s).to eq("single line with RESULT to replace")
+      end
+    end
+  end
+
+  context "replaces with lookbehind assertion" do
+    let(:content) { "123 USD 456 USD 789 EUR" }
+    before { File.write(abs_file_path, content) }
+
+    it "matches only USD preceded by a space" do
+      args = {
+        "file_path" => "sample.txt",
+        "pattern"   => "(?<=\\s)USD(?=\\s|$)",
+        "new_str"   => "EUR",
+      }
+      Dir.cd(temp_dir) do
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(result[:data]["replacements"].as_i).to be 2
+        expect(result[:data]["new_content"].as_s).to eq("123 EUR 456 EUR 789 EUR")
+      end
+    end
+  end
+
+  # -------------------------------------------------
+  # Missing parameter errors
+  # -------------------------------------------------
+  context "fails when file_path is not specified" do
+    before { File.write(abs_file_path, "hello") }
+
+    it "returns an error mentioning file_path" do
+      Dir.cd(temp_dir) do
+        args = {
+          "pattern"   => "foo",
+          "new_str"   => "bar",
+        }
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_false
+        expect(result[:error_msg]).to contain("file_path")
+      end
+    end
+  end
+
+  context "fails when pattern is not specified" do
+    before { File.write(abs_file_path, "hello") }
+
+    it "returns an error mentioning pattern" do
+      Dir.cd(temp_dir) do
+        args = {
+          "file_path" => "sample.txt",
+          "new_str"   => "world",
+        }
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_false
+        expect(result[:error_msg]).to contain("pattern")
+      end
+    end
+  end
+
+  context "fails when new_str is not specified" do
+    before { File.write(abs_file_path, "hello") }
+
+    it "returns an error mentioning new_str" do
+      Dir.cd(temp_dir) do
+        args = {
+          "file_path" => "sample.txt",
+          "pattern"   => "hello",
+        }
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_false
+        expect(result[:error_msg]).to contain("new_str")
+      end
+    end
+  end
+
+  # -------------------------------------------------
+  # File-related errors
+  # -------------------------------------------------
+  context "fails when the specified file does not exist" do
+    it "returns an error mentioning the file does not exist" do
+      Dir.cd(temp_dir) do
+        args = {
+          "file_path" => "nonexistent.txt",
+          "pattern"   => "foo",
+          "new_str"   => "bar",
+        }
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_false
+        expect(result[:error_msg]).to contain("does not exist")
+      end
+    end
+  end
+
+  context "fails when the regex matches nothing in the file" do
+    let(:content) { "nothing matches this pattern" }
+    before { File.write(file_path, content) }
+
+    it "returns an error about no strings being found" do
+      Dir.cd(temp_dir) do
+        args = {
+          "file_path" => file_path,
+          "pattern"   => "xyzxyzxyz",
+          "new_str"   => "replacement",
+        }
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_false
+        expect(result[:error_msg]).to contain("Unable to find")
+      end
+    end
+  end
+
+  context "fails when regex is invalid" do
+    let(:content) { "some text" }
+    before { File.write(file_path, content) }
+
+    it "returns an error for malformed regex" do
+      Dir.cd(temp_dir) do
+        args = {
+          "file_path" => file_path,
+          "pattern"   => "[invalid",
+          "new_str"   => "replaced",
+        }
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_false
+        expect(result[:error_msg]).to contain("error")
+      end
+    end
+  end
+
+  # -------------------------------------------------
+  # Security scenarios
+  # -------------------------------------------------
+  context "blocks paths resolved outside the current directory" do
+    let(:outside_path) { File.expand_path("/tmp/outside_test_file") }
+
+    after { File.delete?(outside_path) }
+
+    it "returns an error indicating the path is not allowed" do
+      File.write(outside_path, "some content")
+
+      Dir.cd(temp_dir) do
+        args = {
+          "file_path" => "../tmp/outside_test_file",
+          "pattern"   => "foo",
+          "new_str"   => "bar",
+        }
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_false
+        expect(result[:error_msg]).to contain("not allowed")
+      end
+    end
+  end
+
+  context "blocks multiple ../ sequences in the path" do
+    it "returns an error for deeply nested path traversal" do
+      Dir.cd(temp_dir) do
+        args = {
+          "file_path" => "deep/../../../etc/passwd",
+          "pattern"   => "foo",
+          "new_str"   => "bar",
+        }
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_false
+        expect(result[:error_msg]).to contain("not allowed")
+      end
+    end
+  end
+end

--- a/spec/unit/tools/file_management/create_directory_tool_spec.cr
+++ b/spec/unit/tools/file_management/create_directory_tool_spec.cr
@@ -1,0 +1,267 @@
+require "../../../spec_helper"
+require "json"
+
+Spectator.describe Tools::FileManagement::CreateDirectoryTool do
+  let(:temp_dir) { File.expand_path("spec/tmp_create_dir_test") }
+  let(:runner) { Tools::FileManagement::CreateDirectoryTool::Runner.new }
+
+  def rm_rf(path)
+    return unless path.starts_with?(temp_dir)
+    if Dir.exists?(path)
+      Dir.each_child(path) do |entry|
+        full = File.join(path, entry)
+        if Dir.exists?(full)
+          rm_rf(full)
+        else
+          File.delete?(full)
+        end
+      end
+      Dir.delete?(path)
+    end
+  end
+
+  before { Dir.mkdir_p(temp_dir) }
+  after { rm_rf(temp_dir) if Dir.exists?(temp_dir) }
+
+  def parse_run_result(result_json)
+    parsed = JSON.parse(result_json)
+    hash_val = parsed.as_h?
+    if hash_val
+      err = hash_val["error"]?
+      if err
+         return { success: false, data: parsed, error_msg: err.as_s }
+      end
+    end
+     { success: true, data: parsed, error_msg: nil }
+  end
+
+    # -------------------------------------------------
+    # Successful directory creation scenarios
+    # -------------------------------------------------
+
+  context "creates a single-level directory" do
+    let(:dir_path) { File.join(temp_dir, "new_directory") }
+
+    it "returns success with the directory path" do
+      Dir.cd(temp_dir) do
+        args = {
+              "directory_path" => "new_directory",
+            }
+
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(result[:error_msg]).to be_nil
+        expect(result[:data]["directory_path"].as_s).to eq("new_directory")
+        expect(result[:data]["status"].as_s).to eq("created")
+        expect(File.exists?(dir_path)).to be_true
+        expect(Dir.exists?(dir_path)).to be_true
+      end
+    end
+  end
+
+  context "creates a nested directory with intermediate paths missing" do
+    let(:nested_dir) { File.join(temp_dir, "level1", "level2", "level3") }
+
+    it "creates all intermediate directories and the final directory" do
+      Dir.cd(temp_dir) do
+        args = {
+              "directory_path" => "level1/level2/level3",
+            }
+
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(result[:error_msg]).to be_nil
+        expect(result[:data]["directory_path"].as_s).to eq("level1/level2/level3")
+        expect(File.exists?(nested_dir)).to be_true
+        expect(Dir.exists?(nested_dir)).to be_true
+      end
+    end
+  end
+
+  context "creates directory using forward slashes on any OS" do
+    let(:dir_path) { File.join(temp_dir, "subdir", "another") }
+
+    it "creates the full path successfully" do
+      Dir.cd(temp_dir) do
+        args = {
+              "directory_path" => "subdir/another",
+            }
+
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(File.exists?(dir_path)).to be_true
+      end
+    end
+  end
+
+    # -------------------------------------------------
+    # Security scenarios
+    # -------------------------------------------------
+
+  context "blocks paths resolved outside the current directory" do
+    it "returns an error when path contains ../ going outside temp_dir" do
+      args = {
+            "directory_path" => "../outside_dir",
+          }
+
+      # No Dir.cd - test runs from project root
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).not_to be_nil
+      expect(result[:error_msg]).to match(/outside/)
+    end
+  end
+
+  context "blocks paths with multiple levels of parent navigation" do
+    let(:safe_subdir) { File.join(temp_dir, "safe") }
+
+    before { Dir.mkdir_p(safe_subdir) }
+
+    it "returns an error when pattern contains../../" do
+      args = {
+            "directory_path" => "safe/../../etc/testdir",
+          }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).not_to be_nil
+      expect(result[:error_msg]).to match(/outside/)
+    end
+  end
+
+    # -------------------------------------------------
+    # Missing parameter scenarios
+    # -------------------------------------------------
+
+  context "fails when directory_path is not provided" do
+    it "returns an error" do
+      args = {} of String => JSON::Any
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).not_to be_nil
+      expect(result[:error_msg]).to match(/directory_path/)
+    end
+  end
+
+  context "fails when directory_path is nil" do
+    it "returns an error" do
+      args = {
+            "directory_path" => nil,
+          }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).not_to be_nil
+    end
+  end
+
+    # -------------------------------------------------
+    # Edge case scenarios
+    # -------------------------------------------------
+
+  context "handles empty string directory_path" do
+    it "creates directory in current directory" do
+      Dir.cd(temp_dir) do
+        args = {
+              "directory_path" => "",
+            }
+
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(File.exists?(temp_dir)).to be_true
+      end
+    end
+  end
+
+  context "handles existing directory gracefully" do
+    let(:existing_dir) { File.join(temp_dir, "existing_dir") }
+
+    before { Dir.mkdir_p(existing_dir) }
+
+    it "succeeds even if directory already exists" do
+      Dir.cd(temp_dir) do
+        args = {
+              "directory_path" => "existing_dir",
+            }
+
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+      end
+    end
+  end
+
+  context "handles partially existing nested directories" do
+    let(:partial_dir) { File.join(temp_dir, "partial", "sub") }
+
+    before { Dir.mkdir_p(File.dirname(partial_dir)) }
+
+    it "creates the remaining subdirectory successfully" do
+      Dir.cd(temp_dir) do
+        args = {
+              "directory_path" => "partial/sub",
+            }
+
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(File.exists?(partial_dir)).to be_true
+      end
+    end
+  end
+
+  context "handles directory names with spaces" do
+    let(:dir_path) { File.join(temp_dir, "my new directory") }
+
+    it "creates the directory with spaces in the name" do
+      Dir.cd(temp_dir) do
+        args = {
+              "directory_path" => "my new directory",
+            }
+
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(File.exists?(dir_path)).to be_true
+      end
+    end
+  end
+
+  context "handles directory names with special characters" do
+    let(:dir_path) { File.join(temp_dir, "test-dir_2024") }
+
+    it "creates the directory with special characters" do
+      Dir.cd(temp_dir) do
+        args = {
+              "directory_path" => "test-dir_2024",
+            }
+
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(File.exists?(dir_path)).to be_true
+      end
+    end
+  end
+end

--- a/spec/unit/tools/file_management/find_files_tool_spec.cr
+++ b/spec/unit/tools/file_management/find_files_tool_spec.cr
@@ -1,0 +1,331 @@
+require "../../../spec_helper"
+require "json"
+
+Spectator.describe Tools::FileManagement::FindFilesTool do
+  let(:temp_dir) { "spec/tmp_find_test" }
+  let(:runner) { Tools::FileManagement::FindFilesTool::Runner.new }
+
+  def rm_rf(path)
+    return unless path.starts_with?("spec/tmp_find")
+    if Dir.exists?(path)
+      Dir.each_child(path) do |entry|
+        full = File.join(path, entry)
+        if Dir.exists?(full)
+          rm_rf(full)
+        else
+          File.delete?(full)
+        end
+      end
+      Dir.delete?(path)
+    end
+  end
+
+  before { Dir.mkdir_p(temp_dir) }
+  after { rm_rf(temp_dir) if Dir.exists?(temp_dir) }
+
+  def parse_run_result(result_json)
+    parsed = JSON.parse(result_json)
+    hash_val = parsed.as_h?
+    if hash_val
+      err = hash_val["error"]?
+      if err
+        return { success: false, data: parsed, error_msg: err.as_s }
+      end
+    end
+     { success: true, data: parsed, error_msg: nil }
+  end
+
+   # -------------------------------------------------
+    # Successful glob matching scenarios
+    # -------------------------------------------------
+
+  context "finds files matching a simple glob pattern" do
+    let(:file_a) { File.join(temp_dir, "file_a.txt") }
+    let(:file_b) { File.join(temp_dir, "file_b.txt") }
+    let(:file_c) { File.join(temp_dir, "file_c.log") }
+
+    before do
+      File.write(file_a, "a")
+      File.write(file_b, "b")
+      File.write(file_c, "c")
+    end
+
+    it "returns matching file paths as a JSON array" do
+      args = {
+          "expression" => "*.txt",
+          "path"          => temp_dir,
+        }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_true
+      expect(result[:error_msg]).to be_nil
+      expect(result[:data].as_a.size).to eq(2)
+    end
+  end
+
+  context "finds both files and directories in nested paths" do
+    let(:file_in_dir) { File.join(temp_dir, "subdir", "file.txt") }
+
+    before do
+      Dir.mkdir_p(File.dirname(file_in_dir))
+      File.write(file_in_dir, "hello")
+    end
+
+    it "returns matching files when using recursive glob" do
+      args = {
+          "expression" => "**/*",
+          "path"          => temp_dir,
+        }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_true
+      matches = result[:data].as_a
+      expect(matches.size.to_i).to be_gt(0)
+      match_strings = matches.map(&.as_s)
+      expect(match_strings).to contain(file_in_dir)
+    end
+  end
+
+   # -------------------------------------------------
+    # Sorting scenarios
+    # -------------------------------------------------
+
+  context "applies sorting by default" do
+    let(:file_c) { File.join(temp_dir, "c.txt") }
+    let(:file_a) { File.join(temp_dir, "a.txt") }
+    let(:file_b) { File.join(temp_dir, "b.txt") }
+
+    before do
+      File.write(file_c, "c")
+      File.write(file_a, "a")
+      File.write(file_b, "b")
+    end
+
+    it "returns files in sorted order by default" do
+      args = {
+          "expression" => "*.txt",
+          "path"          => temp_dir,
+        }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_true
+      matches = result[:data].as_a.map(&.as_s)
+      expect(matches).to eq(matches.sort)
+    end
+  end
+
+  context "does not sort when sort is false" do
+    let(:file_c) { File.join(temp_dir, "c.txt") }
+    let(:file_a) { File.join(temp_dir, "a.txt") }
+
+    before do
+      File.write(file_c, "c")
+      File.write(file_a, "a")
+    end
+
+    it "returns files in whatever order the glob provides" do
+      args = {
+          "expression" => "*.txt",
+          "path"          => temp_dir,
+          "sort"          => false,
+        }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_true
+      expect(result[:data].as_a.size.to_i).to eq(2)
+    end
+  end
+
+   # -------------------------------------------------
+    # Max limit scenarios
+    # -------------------------------------------------
+
+  context "respects the max parameter" do
+    let(:files) do
+       (1..10).map { |i| File.join(temp_dir, "file_#{i}.txt") }
+    end
+
+    before do
+      files.each { |f| File.write(f, "content") }
+    end
+
+    it "limits results to the specified max count" do
+      args = {
+          "expression" => "*.txt",
+          "path"          => temp_dir,
+          "max"           => 3,
+        }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_true
+      expect(result[:data].as_a.size.to_i).to eq(3)
+    end
+
+    it "returns all matches when max exceeds the number of matches" do
+      args = {
+          "expression" => "*.txt",
+          "path"          => temp_dir,
+          "max"           => 999,
+        }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_true
+      expect(result[:data].as_a.size.to_i).to eq(10)
+    end
+  end
+
+   # -------------------------------------------------
+    # Default path scenarios
+    # -------------------------------------------------
+
+  context "uses '.' as the default path" do
+    before do
+      File.write(File.join(temp_dir, "found.txt"), "yes")
+    end
+
+    it "works when path is not provided" do
+      Dir.cd(temp_dir) do
+        args = {
+            "expression" => "*.txt",
+          }
+
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(result[:data].as_a.size.to_i).to eq(1)
+      end
+    end
+
+    it "treats empty string path as '.'" do
+      Dir.cd(temp_dir) do
+        args = {
+            "expression" => "*.txt",
+            "path"          => "",
+          }
+
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(result[:data].as_a.size.to_i).to eq(1)
+      end
+    end
+  end
+
+   # -------------------------------------------------
+    # Security scenarios
+    # -------------------------------------------------
+
+  context "blocks paths resolved outside the current directory" do
+    let(:outside_path) { File.tempname("_outside.txt") }
+
+    it "returns an error when the glob resolves outside" do
+      args = {
+          "expression" => "*",
+          "path"          => outside_path,
+        }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).not_to be_nil
+      expect(result[:error_msg]).to match(/outside current directory/)
+    end
+  end
+
+  context "blocks paths containing '..' navigation" do
+    let(:safe_dir) { File.join(temp_dir, "safe") }
+
+    before { Dir.mkdir_p(safe_dir) }
+
+    it "returns an error when pattern contains ../" do
+      args = {
+          "expression" => "../../../etc/*.txt",
+          "path"          => safe_dir,
+        }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).not_to be_nil
+      expect(result[:error_msg]).to match(/Reverse path navigation/)
+    end
+
+    it "returns an error when pattern contains /.." do
+      args = {
+          "expression" => "../..",
+          "path"          => safe_dir,
+        }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).not_to be_nil
+      expect(result[:error_msg]).to match(/Reverse path navigation/)
+    end
+  end
+
+   # -------------------------------------------------
+    # Error handling scenarios
+    # -------------------------------------------------
+
+  context "fails when expression is not provided" do
+    it "returns an error" do
+      args = {} of String => JSON::Any
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).not_to be_nil
+      expect(result[:error_msg]).to match(/required glob `expression` was not specified/)
+    end
+  end
+
+  context "handles invalid glob patterns gracefully" do
+    it "returns an error when the glob contains invalid syntax" do
+      args = {
+          "expression" => "[invalid",
+          "path"          => temp_dir,
+        }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_true
+      matches = result[:data].as_a
+      expect(matches.size.to_i).to eq(0)
+    end
+  end
+
+  context "returns empty results when no files match" do
+    it "succeeds with an empty JSON array" do
+      args = {
+          "expression" => "*.xyz_nonexistent",
+          "path"          => temp_dir,
+        }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_true
+      expect(result[:data].as_a.size.to_i).to eq(0)
+    end
+  end
+end

--- a/spec/unit/tools/file_management/rename_file_tool_spec.cr
+++ b/spec/unit/tools/file_management/rename_file_tool_spec.cr
@@ -1,0 +1,285 @@
+require "../../../spec_helper"
+require "json"
+
+Spectator.describe Tools::FileManagement::RenameFileTool do
+  let(:temp_dir) { File.expand_path("spec/tmp_rename_test") }
+  let(:runner) { Tools::FileManagement::RenameFileTool::Runner.new }
+
+  def rm_rf(path)
+    return unless path.starts_with?(temp_dir)
+    if Dir.exists?(path)
+      Dir.each_child(path) do |entry|
+        full = File.join(path, entry)
+        if Dir.exists?(full)
+          rm_rf(full)
+        else
+          File.delete?(full)
+        end
+      end
+      Dir.delete?(path)
+    end
+  end
+
+  before { Dir.mkdir_p(temp_dir) }
+  after { rm_rf(temp_dir) if Dir.exists?(temp_dir) }
+
+  def parse_run_result(result_json)
+    parsed = JSON.parse(result_json)
+    hash_val = parsed.as_h?
+    if hash_val
+      err = hash_val["error"]?
+      if err
+        return {success: false, data: parsed, error_msg: err.as_s}
+      end
+    end
+    {success: true, data: parsed, error_msg: nil}
+  end
+
+  # -------------------------------------------------
+  # Successful rename scenarios
+  # -------------------------------------------------
+
+  context "renames a file in the same directory" do
+    let(:file_path) { File.join(temp_dir, "old_name.txt") }
+    let(:new_path) { File.join(temp_dir, "new_name.txt") }
+
+    before do
+      File.write(file_path, "content")
+    end
+
+    it "returns success with the old and new names" do
+      Dir.cd(temp_dir) do
+        args = {
+          "source_path" => "old_name.txt",
+          "target_path" => "new_name.txt",
+        }
+
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(result[:error_msg]).to be_nil
+        expect(result[:data]["message"].as_s).to match(/old_name\.txt/)
+        expect(result[:data]["message"].as_s).to match(/new_name\.txt/)
+        expect(File.exists?(file_path)).to be_false
+        expect(File.exists?(new_path)).to be_true
+        expect(File.read(new_path)).to eq("content")
+      end
+    end
+  end
+
+  context "moves a file to a subdirectory" do
+    let(:file_path) { File.join(temp_dir, "file.txt") }
+    let(:target_dir) { File.join(temp_dir, "subdir") }
+    let(:new_path) { File.join(target_dir, "file.txt") }
+
+    before do
+      File.write(file_path, "move content")
+      Dir.mkdir_p(target_dir)
+    end
+
+    it "moves the file and returns success" do
+      Dir.cd(temp_dir) do
+        args = {
+          "source_path" => "file.txt",
+          "target_path" => "subdir/file.txt",
+        }
+
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(result[:error_msg]).to be_nil
+        expect(File.exists?(file_path)).to be_false
+        expect(File.exists?(new_path)).to be_true
+      end
+    end
+  end
+
+  context "renames a file with spaces in the filename" do
+    let(:file_path) { File.join(temp_dir, "old file name.txt") }
+    let(:new_path) { File.join(temp_dir, "new file name.txt") }
+
+    before do
+      File.write(file_path, "spaces content")
+    end
+
+    it "renames the file successfully" do
+      Dir.cd(temp_dir) do
+        args = {
+          "source_path" => "old file name.txt",
+          "target_path" => "new file name.txt",
+        }
+
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(File.exists?(new_path)).to be_true
+      end
+    end
+  end
+
+  context "renames a file with special characters" do
+    let(:file_path) { File.join(temp_dir, "test-file_2024.txt") }
+    let(:new_path) { File.join(temp_dir, "new-test_v1.txt") }
+
+    before do
+      File.write(file_path, "special content")
+    end
+
+    it "renames the file with special chars successfully" do
+      Dir.cd(temp_dir) do
+        args = {
+          "source_path" => "test-file_2024.txt",
+          "target_path" => "new-test_v1.txt",
+        }
+
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_true
+        expect(File.exists?(new_path)).to be_true
+      end
+    end
+  end
+
+  # -------------------------------------------------
+  # Security scenarios
+  # -------------------------------------------------
+
+  context "blocks renaming paths resolved outside the current directory" do
+    it "returns an error when source_path escapes current dir" do
+      args = {
+        "source_path" => "../outside_dir/file.txt",
+        "target_path" => "some_name.txt",
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).not_to be_nil
+      expect(result[:error_msg]).to match(/not allowed/)
+    end
+  end
+
+  context "blocks renaming a file inside the .deleted_files directory" do
+    let(:deleted_dir) { File.expand_path(".deleted_files") }
+    let(:file_in_deleted) { File.join(deleted_dir, "temp_file.txt") }
+
+    before do
+      Dir.mkdir_p(deleted_dir) unless Dir.exists?(deleted_dir)
+      File.write(file_in_deleted, "deleted content")
+    end
+
+    after do
+      File.delete?(file_in_deleted)
+      if Dir.exists?(deleted_dir) && Dir.empty?(deleted_dir)
+        Dir.delete(deleted_dir)
+      end
+    end
+
+    it "returns an error when trying to rename a file in .deleted_files" do
+      Dir.cd(temp_dir) do
+        args = {
+          "source_path" => ".deleted_files/temp_file.txt",
+          "target_path" => "renamed.txt",
+        }
+
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_false
+        expect(result[:error_msg]).not_to be_nil
+        expect(result[:error_msg]).to match(/deleted_files/)
+      end
+    end
+  end
+
+  # -------------------------------------------------
+  # Missing parameter scenarios
+  # -------------------------------------------------
+
+  context "fails when source_path is not provided" do
+    it "returns an error" do
+      args = {
+        "target_path" => "some_name.txt",
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).not_to be_nil
+      expect(result[:error_msg]).to match(/source_path/)
+    end
+  end
+
+  context "fails when target_path is not provided" do
+    it "returns an error" do
+      args = {
+        "source_path" => "some_name.txt",
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).not_to be_nil
+      expect(result[:error_msg]).to match(/target_path/)
+    end
+  end
+
+  # -------------------------------------------------
+  # Non-existent file scenario
+  # -------------------------------------------------
+
+  context "fails when the source file does not exist" do
+    it "returns an error for a non-existent source path" do
+      Dir.cd(temp_dir) do
+        args = {
+          "source_path" => "nonexistent_file.txt",
+          "target_path" => "new_file.txt",
+        }
+
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_false
+        expect(result[:error_msg]).not_to be_nil
+        expect(result[:error_msg]).to match(/does not exist/)
+      end
+    end
+  end
+
+  # -------------------------------------------------
+  # Target already exists scenario
+  # -------------------------------------------------
+
+  context "fails when the target name already exists" do
+    let(:source_file) { File.join(temp_dir, "source.txt") }
+    let(:target_file) { File.join(temp_dir, "target.txt") }
+
+    before do
+      File.write(source_file, "source content")
+      File.write(target_file, "target content")
+    end
+
+    it "returns an error when target path already exists" do
+      Dir.cd(temp_dir) do
+        args = {
+          "source_path" => "source.txt",
+          "target_path" => "target.txt",
+        }
+
+        result_json = runner.execute(JSON.parse(args.to_json))
+        result = parse_run_result(result_json)
+
+        expect(result[:success]).to be_false
+        expect(result[:error_msg]).not_to be_nil
+        expect(result[:error_msg]).to match(/already exists/)
+      end
+    end
+  end
+end

--- a/spec/unit/tools/file_management/search_files_tool_spec.cr
+++ b/spec/unit/tools/file_management/search_files_tool_spec.cr
@@ -1,0 +1,379 @@
+require "../../../spec_helper"
+require "json"
+
+Spectator.describe Tools::FileManagement::SearchFilesTool do
+  let(:temp_dir) { "spec/tmp_search_test" }
+  let(:runner) { Tools::FileManagement::SearchFilesTool::Runner.new }
+
+  def rm_rf(path)
+    return unless path.starts_with?("spec/tmp_search")
+    if Dir.exists?(path)
+      Dir.each_child(path) do |entry|
+        full = File.join(path, entry)
+        if Dir.exists?(full)
+          rm_rf(full)
+        else
+          File.delete?(full)
+        end
+      end
+      Dir.delete?(path)
+    end
+  end
+
+  before { Dir.mkdir_p(temp_dir) }
+  after { rm_rf(temp_dir) if Dir.exists?(temp_dir) }
+
+  def make_args(**opts)
+    JSON.parse(opts.to_json)
+  end
+
+  def parse_run_result(result_json)
+    parsed = JSON.parse(result_json)
+    hash_val = parsed.as_h?
+    if hash_val
+      err = hash_val["error"]?
+      if err
+        return { success: false, data: parsed, error_msg: err.as_s }
+      end
+    end
+     { success: true, data: parsed, error_msg: nil }
+  end
+
+    # -------------------------------------------------
+    # Successful string search scenarios
+    # -------------------------------------------------
+
+  context "searches for a pattern in files" do
+    let(:file_a) { File.join(temp_dir, "file_a.txt") }
+    let(:file_b) { File.join(temp_dir, "file_b.txt") }
+
+    before do
+      File.write(file_a, "hello world\nfoo bar\n")
+      File.write(file_b, "nothing here\n")
+    end
+
+    it "returns matching lines with file paths and line numbers" do
+      args = make_args(
+        files: File.join(temp_dir, "*.txt"),
+        pattern: "hello",
+      )
+
+      result_json = runner.execute(args)
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_true
+      expect(result[:error_msg]).to be_nil
+      matches = result[:data].as_a
+      expect(matches.size.to_i).to eq(1)
+      match_tuple = matches.first.as_h
+      expect(match_tuple["file"].as_s).to eq(file_a)
+      match_lines = match_tuple["matches"].as_a
+      expect(match_lines.size.to_i).to eq(1)
+      expect(match_lines.first.as_h["line"].as_s).to eq("hello world")
+      expect(match_lines.first.as_h["num"].as_i).to eq(1)
+    end
+  end
+
+  context "finds multiple matches across multiple files" do
+    let(:file_a) { File.join(temp_dir, "file_a.txt") }
+    let(:file_b) { File.join(temp_dir, "file_b.txt") }
+
+    before do
+      File.write(file_a, "foo bar\nfoo baz\n")
+      File.write(file_b, "foo qux\nnot here\n")
+    end
+
+    it "returns all matches from all files" do
+      args = make_args(
+        files: File.join(temp_dir, "*.txt"),
+        pattern: "foo",
+      )
+
+      result_json = runner.execute(args)
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_true
+      matches = result[:data].as_a
+      expect(matches.size.to_i).to eq(2)
+    end
+  end
+
+  context "returns no matches when pattern is not found" do
+    let(:file_a) { File.join(temp_dir, "file_a.txt") }
+
+    before do
+      File.write(file_a, "hello world\nfoo bar\n")
+    end
+
+    it "succeeds with an empty results array" do
+      args = make_args(
+        files: File.join(temp_dir, "*.txt"),
+        pattern: "notfound",
+      )
+
+      result_json = runner.execute(args)
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_true
+      matches = result[:data].as_a
+      expect(matches.size.to_i).to eq(0)
+    end
+  end
+
+    # -------------------------------------------------
+    # Regex search scenario
+    # -------------------------------------------------
+
+  context "searches using regex when search_regex is true" do
+    let(:file_a) { File.join(temp_dir, "file_a.txt") }
+
+    before do
+      File.write(file_a, "cat123\ndog456\ncat789\n")
+    end
+
+    it "matches lines using the regex pattern" do
+      args = make_args(
+        files: File.join(temp_dir, "*.txt"),
+        pattern: "cat\\d+",
+        search_regex: true,
+      )
+
+      result_json = runner.execute(args)
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_true
+      matches = result[:data].as_a
+      expect(matches.size.to_i).to eq(1)
+      match_lines = matches.first.as_h["matches"].as_a
+      expect(match_lines.size.to_i).to eq(2)
+      expect(match_lines.first.as_h["line"].as_s).to eq("cat123")
+      expect(match_lines.last.as_h["line"].as_s).to eq("cat789")
+    end
+  end
+
+  context "does regex matching when search_regex is false" do
+    let(:file_a) { File.join(temp_dir, "file_a.txt") }
+
+    before do
+      File.write(file_a, "cat123\ncat\n")
+    end
+
+    it "matches literal string only" do
+      args = make_args(
+        files: File.join(temp_dir, "*.txt"),
+        pattern: "cat\\d+",
+        search_regex: false,
+      )
+
+      result_json = runner.execute(args)
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_true
+      matches = result[:data].as_a
+      expect(matches.size.to_i).to eq(0)
+    end
+  end
+
+    # -------------------------------------------------
+    # Max files limit scenarios
+    # -------------------------------------------------
+
+  context "respects the max_files parameter" do
+    let(:max_files_default) { 1000 }
+
+    let(:files) do
+       (1..max_files_default).map { |i| File.join(temp_dir, "file_#{i}.txt") }
+    end
+
+    before do
+      files.each { |f| File.write(f, "hello") }
+    end
+
+    it "limits results to the specified max_files count" do
+      args = make_args(
+        files: File.join(temp_dir, "*.txt"),
+        pattern: "hello",
+        max_files: 3,
+      )
+
+      result_json = runner.execute(args)
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_true
+      expect(result[:data].as_a.size.to_i).to eq(3)
+    end
+
+    it "returns all matches when max_files exceeds the number of matches" do
+      args = make_args(
+        files: File.join(temp_dir, "*.txt"),
+        pattern: "hello",
+        max_files: 9999,
+      )
+
+      result_json = runner.execute(args)
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_true
+      expect(result[:data].as_a.size.to_i).to eq(max_files_default)
+    end
+  end
+
+    # -------------------------------------------------
+    # Default values scenarios
+    # -------------------------------------------------
+
+  context "uses default values when params are omitted" do
+    let(:file_a) { File.join(temp_dir, "file_a.txt") }
+
+    before do
+      File.write(file_a, "default test line")
+    end
+
+    it "defaults files pattern to all files when not provided" do
+      args = make_args(
+        files: File.join(temp_dir, "*"),
+        pattern: "default test line",
+        )
+
+      result_json = runner.execute(args)
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_true
+      expect(result[:data].as_a.size.to_i).to eq(1)
+    end
+
+    it "defaults search_regex to false when not provided" do
+      args = make_args(
+        files: File.join(temp_dir, "*.txt"),
+        pattern: "def",
+      )
+
+      result_json = runner.execute(args)
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_true
+      matches = result[:data].as_a
+      expect(matches.size.to_i).to eq(1)
+    end
+  end
+
+    # -------------------------------------------------
+    # Security scenarios
+    # -------------------------------------------------
+
+  context "blocks paths resolved outside the current directory" do
+    let(:outside_path) { File.tempname("_outside.txt") }
+
+    it "returns an error when the files pattern resolves outside" do
+      args = make_args(
+        files: outside_path,
+        pattern: "test",
+      )
+
+      result_json = runner.execute(args)
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).not_to be_nil
+      expect(result[:error_msg]).to match(/outside current directory/)
+    end
+  end
+
+  context "blocks paths containing '..' navigation" do
+    let(:safe_dir) { File.join(temp_dir, "safe") }
+
+    before { Dir.mkdir_p(safe_dir) }
+
+    it "returns an error when files pattern contains ../" do
+      args = make_args(
+        files: "spec/../etc/*.txt",
+        pattern: "test",
+      )
+
+      result_json = runner.execute(args)
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).not_to be_nil
+      expect(result[:error_msg]).to match(/Reverse path navigation/)
+    end
+
+    it "returns an error when files pattern contains /.." do
+      args = make_args(
+        files: "spec/..",
+        pattern: "test",
+      )
+
+      result_json = runner.execute(args)
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).not_to be_nil
+      expect(result[:error_msg]).to match(/Reverse path navigation/)
+    end
+  end
+
+    # -------------------------------------------------
+    # Error handling scenarios
+    # -------------------------------------------------
+
+  context "fails when files is not provided" do
+    it "returns an error" do
+      args = make_args()
+
+      result_json = runner.execute(args)
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).not_to be_nil
+    end
+  end
+
+  context "fails when pattern is not provided" do
+    it "returns an error" do
+      args = make_args(files: "*.txt")
+
+      result_json = runner.execute(args)
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).not_to be_nil
+      expect(result[:error_msg]).to match(/required search pattern/)
+    end
+  end
+
+  context "fails when pattern is empty" do
+    before do
+      File.write(File.join(temp_dir, "empty.txt"), "content")
+    end
+
+    it "returns an error for a whitespace-only pattern" do
+      args = make_args(
+        files: File.join(temp_dir, "*.txt"),
+        pattern: "      ",
+      )
+
+      result_json = runner.execute(args)
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_false
+      expect(result[:error_msg]).not_to be_nil
+      expect(result[:error_msg]).to match(/empty/)
+    end
+  end
+
+  context "handles invalid file patterns gracefully" do
+    it "returns an error when the files pattern matches nothing" do
+      args = make_args(
+        files: "*.xyz_nonexistent",
+        pattern: "hello",
+      )
+
+      result_json = runner.execute(args)
+      result = parse_run_result(result_json)
+
+      expect(result[:success]).to be_true
+      expect(result[:data].as_a.size.to_i).to eq(0)
+    end
+  end
+end

--- a/spec/unit/tools/text_editing/insert_lines_in_text_file_tool_spec.cr
+++ b/spec/unit/tools/text_editing/insert_lines_in_text_file_tool_spec.cr
@@ -1,0 +1,238 @@
+require "../../../spec_helper"
+require "json"
+
+Spectator.describe Tools::TextEditing::InsertLinesInTextFileTool do
+  # fixtures
+  let(:temp_dir) { "spec/tmp_test" }
+  let(:file_path) { File.join(temp_dir, "sample.txt") }
+  let(:runner) { Tools::TextEditing::InsertLinesInTextFileTool::Runner.new }
+
+  before { Dir.mkdir_p(temp_dir) }
+  after do
+    File.delete?(file_path)
+    Dir.delete?(temp_dir)
+  end
+
+  # -------------------------------------------------
+  # Successful insertion scenarios
+  # -------------------------------------------------
+
+  context "inserts text at the beginning of the file (line 0)" do
+    let(:original_content) { "first line\nsecond line\nthird line\n" }
+    let(:insert_text) { "INSERTED AT START\n" }
+
+    before do
+      File.write(file_path, original_content)
+    end
+
+    it "succeeds and updates the file correctly" do
+      args = {
+        "file_path"   => file_path,
+        "insert_line" => 0,
+        "insert_text" => insert_text,
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      # no error should be present
+      expect(result["error"]?).to be_nil
+
+      # verify file content
+      revised_content = File.read(file_path)
+      expect(revised_content).to eq("INSERTED AT START\nfirst line\nsecond line\nthird line\n")
+    end
+  end
+
+  context "inserts text after a specific line (e.g., after line 1)" do
+    let(:original_content) { " lineA\n lineB\n lineC\n" }
+    let(:insert_text) { " NEW CONTENT AFTER LINE 1\n" }
+
+    before do
+      File.write(file_path, original_content)
+    end
+
+    it "succeeds and places the new text after line 1" do
+      args = {
+        "file_path"   => file_path,
+        "insert_line" => 1,
+        "insert_text" => insert_text,
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result["error"]?).to be_nil
+
+      revised_content = File.read(file_path)
+      expect(revised_content).to eq(" lineA\n NEW CONTENT AFTER LINE 1\n lineB\n lineC\n")
+    end
+  end
+
+  context "appends text at the end of the file (line -1)" do
+    let(:original_content) { "START\nMIDDLE\n" }
+    let(:insert_text) { "\nAPPEND TEXT" }
+
+    before do
+      File.write(file_path, original_content)
+    end
+
+    it "succeeds and appends the text at the end" do
+      args = {
+        "file_path"   => file_path,
+        "insert_line" => -1,
+        "insert_text" => insert_text,
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result["error"]?).to be_nil
+
+      revised_content = File.read(file_path)
+      expect(revised_content).to eq("START\nMIDDLE\n\nAPPEND TEXT")
+    end
+  end
+
+  # -------------------------------------------------
+  # Error handling scenarios
+  # -------------------------------------------------
+
+  context "fails when file_path is not provided" do
+    it "returns an error" do
+      args = {
+        "insert_line" => 0,
+        "insert_text" => "anything", # file_path missing
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key("error")
+      expect(result["error"]).to match(/The required `file_path` was not specified/)
+    end
+  end
+
+  context "fails when insert_line is not provided" do
+    let(:file_path) { File.join(temp_dir, "exist.txt") }
+    let(:original_content) { "content" }
+    before do
+      File.write(file_path, original_content)
+      Dir.mkdir_p(temp_dir)
+    end
+
+    it "returns an error" do
+      args = {
+        "file_path"   => file_path,
+        "insert_text" => "new text", # insert_line missing
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key("error")
+      expect(result["error"]).to match(/The required `insert_line` was not specified/)
+    end
+  end
+
+  context "fails when insert_text is not provided" do
+    let(:file_path) { File.join(temp_dir, "exist.txt") }
+    let(:original_content) { "content" }
+    before do
+      File.write(file_path, original_content)
+      Dir.mkdir_p(temp_dir)
+    end
+
+    it "returns an error" do
+      args = {
+        "file_path"   => file_path,
+        "insert_line" => 0,
+        # insert_text missing
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key("error")
+      expect(result["error"]).to match(/The required `insert_text` was not specified/)
+    end
+  end
+
+  context "fails when the target file does not exist" do
+    it "returns an error" do
+      args = {
+        "file_path"   => "nonexistent.txt",
+        "insert_line" => 0,
+        "insert_text" => "anything",
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key("error")
+      expect(result["error"]).to match(/The specified file 'nonexistent.txt' does not exist/)
+    end
+  end
+
+  context "fails when the specified path is outside the current directory" do
+    let(:outside_path) { File.tempname("_outside.txt") }
+
+    it "returns an error" do
+      args = {
+        "file_path"   => outside_path,
+        "insert_line" => 0,
+        "insert_text" => "test",
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key("error")
+      expect(result["error"]).to match(/The specified path '#{Regex.escape(outside_path)}' is not allowed/)
+    end
+  end
+
+  context "fails when the file_path points to a non-file (e.g., a directory)" do
+    let(:dir_path) { File.join(temp_dir, "subdir") }
+
+    before { Dir.mkdir_p(dir_path) }
+    after { Dir.delete?(dir_path) }
+
+    it "returns an error" do
+      args = {
+        "file_path"   => dir_path,
+        "insert_line" => 0,
+        "insert_text" => "test",
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key("error")
+      expect(result["error"]).to match(/The specified file '#{Regex.escape(dir_path)}' does not exist or is not a file/)
+    end
+  end
+
+  context "fails when insert_line is not an integer" do
+    let(:file_path) { File.join(temp_dir, "exist.txt") }
+    let(:original_content) { "content" }
+    before do
+      File.write(file_path, original_content)
+      Dir.mkdir_p(temp_dir)
+    end
+
+    it "returns an error" do
+      args = {
+        "file_path"   => file_path,
+        "insert_line" => "invalid",
+        "insert_text" => "new",
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key("error")
+      expect(result["error"]).to match(/The required `insert_line` was not specified/)
+    end
+  end
+end

--- a/spec/unit/tools/text_editing/read_text_file_tool_spec.cr
+++ b/spec/unit/tools/text_editing/read_text_file_tool_spec.cr
@@ -1,0 +1,178 @@
+require "../../../spec_helper"
+require "json"
+
+Spectator.describe Tools::TextEditing::ReadTextFileTool do
+  let(:temp_dir) { "spec/tmp_test" }
+  let(:file_path) { File.join(temp_dir, "sample.txt") }
+  let(:runner) { Tools::TextEditing::ReadTextFileTool::Runner.new }
+
+  before { Dir.mkdir_p(temp_dir) }
+  after do
+    File.delete?(file_path)
+    Dir.delete?(temp_dir)
+  end
+
+  # ---- Successful read scenarios ----
+  context "reads the entire file without line numbers" do
+    let(:original_content) { "line 1\nline 2\nline 3\n" }
+    before { File.write(file_path, original_content) }
+
+    it "returns the file content as a string" do
+      args = {
+        "file_path"            => file_path,
+        "include_line_numbers" => false,
+        "line_range"           => [1, -1],
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result["error"]?).to be_nil
+      expect(result["content"]?).to eq(original_content)
+    end
+  end
+
+  context "reads the entire file with line numbers" do
+    let(:original_content) { "first\nsecond\nthird\n" }
+    before { File.write(file_path, original_content) }
+
+    it "includes line numbers in output when requested" do
+      args = {
+        "file_path"            => file_path,
+        "include_line_numbers" => true,
+        "line_range"           => [1, -1],
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result["error"]?).to be_nil
+      lines = result["content"].as_s.split("\n")
+      expect(lines.size).to eq(4)
+      expect(lines[0]).to match(/^\s*1\tfirst/)
+      expect(lines[1]).to match(/^\s*2\tsecond/)
+      expect(lines[2]).to match(/^\s*3\tthird/)
+    end
+  end
+
+  context "reads a specific line range (e.g., lines 2-3)" do
+    let(:original_content) { "line 1\nline 2\nline 3\nline 4\n" }
+    before { File.write(file_path, original_content) }
+
+    it "returns only the specified lines" do
+      args = {
+        "file_path"            => file_path,
+        "include_line_numbers" => false,
+        "line_range"           => [2, 3],
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result["error"]?).to be_nil
+      expect(result["content"].as_s).to eq("line 2\nline 3\n")
+    end
+  end
+
+  context "reads lines with line numbers in a range" do
+    let(:original_content) { "A\nB\nC\nD\n" }
+    before { File.write(file_path, original_content) }
+
+    it "includes line numbers for the specified range" do
+      args = {
+        "file_path"            => file_path,
+        "include_line_numbers" => true,
+        "line_range"           => [2, 4],
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result["error"]?).to be_nil
+      lines = result["content"].as_s.split("\n")
+      expect(lines.size).to eq(3 + 1)
+      expect(lines[0]).to match(/^\s*2\tB/)
+      expect(lines[1]).to match(/^\s*3\tC/)
+      expect(lines[2]).to match(/^\s*4\tD/)
+    end
+  end
+
+  # ---- Error handling scenarios ----
+  context "fails when file_path is not provided" do
+    it "returns an error" do
+      args = {
+        "include_line_numbers" => false,
+        "line_range"           => [1, -1],
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result["error"]).not_to be_nil
+      expect(result["error"].as_s).to match(/The required `file_path` was not specified/)
+    end
+  end
+
+  context "fails when the specified file does not exist" do
+    it "returns an error" do
+      args = {
+        "file_path"            => "nonexistent.txt",
+        "include_line_numbers" => false,
+        "line_range"           => [1, -1],
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result["error"]).not_to be_nil
+      expect(result["error"]).to match(/The specified file 'nonexistent.txt' does not exist/)
+    end
+  end
+
+  context "fails when the path points outside the allowed directory" do
+    let(:outside_path) { File.tempname("_outside.txt") }
+
+    it "returns an error" do
+      args = {
+        "file_path"            => outside_path,
+        "include_line_numbers" => false,
+        "line_range"           => [1, -1],
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result["error"]).not_to be_nil
+      expect(result["error"]).to match(/Access to the specified path '#{Regex.escape(outside_path)}' is not allowed/)
+    end
+  end
+
+  context "fails when an invalid line_range format is given" do
+    let(:original_content) { "content" }
+    before { File.write(file_path, original_content) }
+
+    it "returns an error" do
+      args = {
+        "file_path"            => file_path,
+        "include_line_numbers" => false,
+        "line_range"           => "invalid", # not an array
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result["error"]).not_to be_nil
+      expect(result["error"]).to match(/The `line_range` must be an array with two integers/)
+    end
+  end
+
+  context "fails when line_range contains non-integer values" do
+    let(:original_content) { "content" }
+    before { File.write(file_path, original_content) }
+
+    it "returns an error" do
+      args = {
+        "file_path"            => file_path,
+        "include_line_numbers" => false,
+        "line_range"           => [1, "two"],
+      }
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result["error"]).not_to be_nil
+      expect(result["error"]).to match(/The `line_range` must be an array with two integers/)
+    end
+  end
+end

--- a/spec/unit/tools/text_editing/replace_lines_in_text_file_tool_spec.cr
+++ b/spec/unit/tools/text_editing/replace_lines_in_text_file_tool_spec.cr
@@ -9,7 +9,10 @@ Spectator.describe Tools::TextEditing::ReplaceLinesInTextFileTool do
   let(:file_path) { File.join(temp_dir, "sample.txt") }
 
   before { Dir.mkdir_p(temp_dir) }
-  after { File.delete?(file_path) }
+  after do
+    File.delete?(file_path)
+    Dir.delete?(temp_dir)
+  end
 
   let(:runner) { Tools::TextEditing::ReplaceLinesInTextFileTool::Runner.new }
 

--- a/spec/unit/tools/text_editing/str_replace_in_text_file_tool_spec.cr
+++ b/spec/unit/tools/text_editing/str_replace_in_text_file_tool_spec.cr
@@ -9,7 +9,10 @@ Spectator.describe Tools::TextEditing::ReplaceTextInTextFileTool do
   let(:file_path) { File.join(temp_dir, "sample.txt") }
 
   before { Dir.mkdir_p(temp_dir) }
-  after { File.delete?(file_path) }
+  after do
+    File.delete?(file_path)
+    Dir.delete?(temp_dir)
+  end
 
   let(:runner) { Tools::TextEditing::ReplaceTextInTextFileTool::Runner.new }
 

--- a/spec/unit/tools/text_editing/write_text_file_tool_spec.cr
+++ b/spec/unit/tools/text_editing/write_text_file_tool_spec.cr
@@ -1,0 +1,249 @@
+require "../../../spec_helper"
+require "json"
+
+Spectator.describe Tools::TextEditing::WriteTextFileTool do
+  # fixtures
+  let(:temp_dir) { "spec/tmp_write_test" }
+  let(:runner) { Tools::TextEditing::WriteTextFileTool::Runner.new }
+
+  # Recursively delete a directory for cleanup
+  def rm_rf(path)
+    return unless path.starts_with?("spec/tmp") # guardrail
+    if Dir.exists?(path)
+      Dir.each_child(path) do |entry|
+        full = File.join(path, entry)
+        if Dir.exists?(full)
+          rm_rf(full)
+        else
+          File.delete?(full)
+        end
+      end
+      Dir.delete?(path)
+    end
+  end
+
+  before { Dir.mkdir_p(temp_dir) }
+  after { rm_rf(temp_dir) if Dir.exists?(temp_dir) }
+
+  # -------------------------------------------------
+  # Successful write scenarios
+  # -------------------------------------------------
+
+  context "creates a new file with the given content" do
+    let(:file_path) { File.join(temp_dir, "new_file.txt") }
+    let(:content) { "Hello, world!" }
+
+    it "succeeds and writes the content correctly" do
+      args = {
+        "file_path" => file_path,
+        "content"   => content,
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result["error"]?).to be_nil
+      expect(File.read(file_path)).to eq(content)
+      expect(result["message"]).to match(/created successfully/)
+    end
+  end
+
+  context "creates a file in a nested sub-directory if needed" do
+    let(:nested_path) { File.join(temp_dir, "a", "b", "c", "nested.txt") }
+    let(:content) { "nested content" }
+
+    it "creates directories and writes the file" do
+      args = {
+        "file_path" => nested_path,
+        "content"   => content,
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result["error"]?).to be_nil
+      expect(File.read(nested_path)).to eq(content)
+    end
+  end
+
+  context "overwrites an existing file when overwrite is true" do
+    let(:file_path) { File.join(temp_dir, "overwrite_me.txt") }
+    let(:original_content) { "original" }
+    let(:new_content) { "overwritten" }
+
+    before { File.write(file_path, original_content) }
+
+    it "succeeds and replaces the old content" do
+      args = {
+        "file_path" => file_path,
+        "content"   => new_content,
+        "overwrite" => true,
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result["error"]?).to be_nil
+      expect(File.read(file_path)).to eq(new_content)
+      expect(result["message"]).to match(/over-written successfully/)
+    end
+  end
+
+  # -------------------------------------------------
+  # Error handling scenarios
+  # -------------------------------------------------
+
+  context "fails when file_path is not provided" do
+    it "returns an error" do
+      args = {
+        "content" => "some content",
+        # file_path missing
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key("error")
+      expect(result["error"]).to match(/The required file_path was not specified/)
+    end
+  end
+
+  context "fails when content is not provided" do
+    let(:file_path) { File.join(temp_dir, "no_content.txt") }
+
+    it "returns an error" do
+      args = {
+        "file_path" => file_path,
+        # content missing
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key("error")
+      expect(result["error"]).to match(/The required content was not specified/)
+    end
+  end
+
+  context "fails when the file already exists and overwrite is false" do
+    let(:file_path) { File.join(temp_dir, "exists.txt") }
+    let(:original_content) { "I am here" }
+
+    before { File.write(file_path, original_content) }
+
+    it "returns an error without modifying the file" do
+      args = {
+        "file_path" => file_path,
+        "content"   => "new content",
+        "overwrite" => false,
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key("error")
+      expect(result["error"]).to match(/already exists/)
+      expect(File.read(file_path)).to eq(original_content)
+    end
+  end
+
+  context "fails when overwrite is false (default) and file exists" do
+    let(:file_path) { File.join(temp_dir, "defaults_to_no_overwrite.txt") }
+    let(:original_content) { "existing" }
+
+    before { File.write(file_path, original_content) }
+
+    it "returns an error without overwrite param" do
+      args = {
+        "file_path" => file_path,
+        "content"   => "new content",
+        # overwrite not provided, defaults to false
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key("error")
+      expect(result["error"]).to match(/already exists/)
+    end
+  end
+
+  context "fails when the specified path is outside the current directory" do
+    let(:outside_path) { File.tempname("_outside.txt") }
+
+    it "returns an error" do
+      args = {
+        "file_path" => outside_path,
+        "content"   => "test",
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key("error")
+      expect(result["error"]).to match(/is not allowed/)
+    end
+  end
+
+  context "fails when trying to overwrite a file in the deleted files folder" do
+    let(:deleted_path) { File.join(".deleted_files", "old_file.txt") }
+    let(:original_content) { "to be recovered" }
+
+    before do
+      Dir.mkdir_p(".deleted_files")
+      File.write(deleted_path, original_content)
+    end
+
+    after { rm_rf(".deleted_files") }
+
+    it "returns an error even with overwrite=true" do
+      args = {
+        "file_path" => ".deleted_files/old_file.txt",
+        "content"   => "new content",
+        "overwrite" => true,
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key("error")
+      expect(result["error"]).to match(/Cannot overwrite files in the/)
+      expect(File.read(deleted_path)).to eq(original_content)
+    end
+  end
+
+  context "fails when the file_path resolves to a directory" do
+    let(:dir_path) { File.join(temp_dir, "a_dir") }
+
+    before { Dir.mkdir_p(dir_path) }
+
+    it "returns an error because you cannot write to a directory" do
+      args = {
+        "file_path" => dir_path,
+        "content"   => "some content",
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key("error")
+    end
+  end
+
+  context "fails when the parent directory cannot be created" do
+    # Attempt to write into a path where parent dir creation would fail
+    let(:restricted_path) { "/some/restricted/path/file.txt" }
+
+    it "returns an error for write failures" do
+      args = {
+        "file_path" => restricted_path,
+        "content"   => "content",
+      }
+
+      result_json = runner.execute(JSON.parse(args.to_json))
+      result = JSON.parse(result_json).as_h
+
+      expect(result).to have_key("error")
+    end
+  end
+end

--- a/src/tools/toolsets/experimental/regex_edit_tool.cr
+++ b/src/tools/toolsets/experimental/regex_edit_tool.cr
@@ -37,7 +37,13 @@ module Tools::Experimental
         begin
           changes = 0
           content = File.read(resolved_path)
-          new_content = content.gsub(Regex.new(pattern, Regex::Options::MULTILINE)) do |_match|
+          regex = begin
+            Regex.new(pattern, Regex::Options::MULTILINE)
+          rescue ex
+            return error_response("Invalid pattern: #{ex.message}")
+          end
+
+          new_content = content.gsub(regex) do |_match|
             changes += 1 # Count changes so we can detect if nothing changed
             replacement
           end

--- a/src/tools/toolsets/experimental/regex_edit_tool.cr
+++ b/src/tools/toolsets/experimental/regex_edit_tool.cr
@@ -6,16 +6,15 @@ module Tools::Experimental
   # The `RegexTextEditTool` class defines a tool for finding patterns using regex
   # in text-based files and replacing them with new text.
   class RegexTextEditTool < BuiltInFunction
-    name "regex_text_edit_tool"
+    name "str_regex_replace_in_text_file"
 
-    description "Finds patterns using a regex in a text-based file and replaces them with new text. " +
-                "Ensures the file is within the current directory and is a text file."
+    description "Replaces strings that match a regular expression with a new string in a text file within the current directory."
 
     param "file_path", type: Param::Type::Str, required: true,
       description: "The relative path to the file where you want to perform the regex replacement."
     param "pattern", type: Param::Type::Str, required: true,
-      description: "The regex pattern to search for in the file."
-    param "replacement", type: Param::Type::Str, required: true,
+      description: "The regular expression pattern to search for in the file."
+    param "new_str", type: Param::Type::Str, required: true,
       description: "The text to replace the pattern with in the file."
 
     runner Runner
@@ -25,20 +24,26 @@ module Tools::Experimental
       include FileHelper
 
       def execute(args : JSON::Any) : String
-        file_path = args["file_path"]?.try &.as_s? || return error_response("The required file_path was not specified")
-        pattern = args["pattern"]?.try &.as_s? || return error_response("The required pattern was not specified")
-        replacement = args["replacement"]?.try &.as_s? || return error_response("The required replacement was not specified")
+        file_path = args["file_path"]?.try &.as_s? || return error_response("The required `file_path` was not specified")
+        pattern = args["pattern"]?.try &.as_s? || return error_response("The required regex `pattern` was not specified")
+        replacement = args["new_str"]?.try &.as_s? || return error_response("The replacement `new_str` was not specified")
 
         resolved_path = resolve_path(file_path)
 
         return error_response("The specified path '#{file_path}' is not allowed.") unless within_current_directory?(resolved_path)
         return error_response("The specified file '#{file_path}' does not exist.") unless valid_file?(resolved_path)
+        return error_response("Cannot edit files in the `#{DELETED_FILES_PATH}` folder.") if path_in_deleted_files_folder?(resolved_path)
 
         begin
+          changes = 0
           content = File.read(resolved_path)
-          new_content = content.gsub(Regex.new(pattern, Regex::Options::MULTILINE), replacement)
+          new_content = content.gsub(Regex.new(pattern, Regex::Options::MULTILINE)) do |_match|
+            changes += 1 # Count changes so we can detect if nothing changed
+            replacement
+          end
+          raise RuntimeError.new("Unable to find strings matching the regex pattern in the file. Nothing to replace.") if changes.zero?
           File.write(resolved_path, new_content)
-          success_response(file_path, new_content)
+          success_response(file_path, new_content, changes)
         rescue e
           error_response("An error occurred while modifying the file: #{e.message}")
         end
@@ -48,8 +53,8 @@ module Tools::Experimental
         {"error" => message}.to_json
       end
 
-      private def success_response(file_path, content)
-        {file_path: file_path, new_content: content}.to_json
+      private def success_response(file_path, content, changes : Int32)
+        {file_path: file_path, new_content: content, replacements: changes}.to_json
       end
     end
   end

--- a/src/tools/toolsets/text_editing/insert_lines_in_text_file.cr
+++ b/src/tools/toolsets/text_editing/insert_lines_in_text_file.cr
@@ -36,6 +36,7 @@ module Tools::TextEditing
 
         return error_response("The specified path '#{file_path}' is not allowed.") unless within_current_directory?(resolved_path)
         return error_response("The specified file '#{file_path}' does not exist or is not a file.") unless valid_file?(resolved_path)
+        return error_response("Cannot edit files in the `#{DELETED_FILES_PATH}` folder.") if path_in_deleted_files_folder?(resolved_path)
 
         begin
           new_content = if insert_line.negative?

--- a/src/tools/toolsets/text_editing/replace_lines_in_text_file.cr
+++ b/src/tools/toolsets/text_editing/replace_lines_in_text_file.cr
@@ -34,6 +34,7 @@ module Tools::TextEditing
 
         return error_response("The specified path '#{file_path}' is not allowed.") unless within_current_directory?(resolved_path)
         return error_response("The specified file '#{file_path}' does not exist or is not a file.") unless valid_file?(resolved_path)
+        return error_response("Cannot edit files in the `#{DELETED_FILES_PATH}` folder.") if path_in_deleted_files_folder?(resolved_path)
 
         begin
           line_range = parse_line_range(args["line_range"]?)

--- a/src/tools/toolsets/text_editing/replace_text_file_tool.cr
+++ b/src/tools/toolsets/text_editing/replace_text_file_tool.cr
@@ -40,6 +40,7 @@ module Tools::TextEditing
 
         return error_response("The specified path '#{file_path}' is not allowed.") unless within_current_directory?(resolved_path)
         return error_response("The specified file '#{file_path}' does not exist or is not a file.") unless valid_file?(resolved_path)
+        return error_response("Cannot edit files in the `#{DELETED_FILES_PATH}` folder.") if path_in_deleted_files_folder?(resolved_path)
 
         begin
           changes = 0


### PR DESCRIPTION
These test specs were generated using local LLMs (`nemotron-3` and `qwen-3.6`).

I have the following tool settings in my `enkaidu.yml` file to allow using `ops` and approve using `ops test` so that the model could run the tests and fix tests on its own.

```yml
tool_settings:
  shell_command:
    allowed_commands: ["ops"]
    approved_commands: ["ops test"]
```

I defined the following macro in `./enkaidu/macros.yml`

```yml
new_test_spec:
  description: |
    Create a test spec for given file. Run the `!skill.list` macro before running this one.
    - Usage: `!new_test_spec PATH_TO_SRC_FILE.cr`
  queries:
    - /session push
    - /toolset load ShellAccess
    - |
      I want to create a test spec for the source code in %{1}
      - The test spec should be created along side existing tests ./spec/unit/ folder.
      - Create sub-folders that match the location of the class as needed.
      - I use spectator for the test specs. Read the SKILL.md file for the crystal spectator testing skill.
      - Please review an existing test spec for an example of how to test this tool.
      - Once you have a plan for the test spec, present a summary and then proceed with the writing the test specs.
      - After writing the test, you can use the shell command to run `ops test` to verify that the tests are working
      - DO NOT use emdash `‑` or other unicode when an ASCII character will do.
    - |
      IF YOU HAVE NOT written or saved the test file, please proceed.
      ELSE confirm you are done.
    - /session usage
    - /session pop
```

I symlinked the `skills/` folder and `macros/skills.yml` from a clone of the `enkaidu-dev/common-profile` Github repo, which provided the `!skill.list` macro.

Running that before using `!new_test_spec ...` sets up the JSON object with the skills list that has the reference to the Crystal `spectator` testing skill.

Examples of using the macro:

```
!skill.list
!new_test_spec ./src/tools/toolsets/date_and_time/get_current_datetime_tool.cr
!new_test_spec ./src/tools/toolsets/file_management/rename_file_tool.cr
```

Because the test generator runs in a forked session, the `!new_test_spec` macro can be called again as the session context is clean after each run, with the skills list in the context and nothing else.
