### PR TITLE
Use mini-scroll region for thinking in quiet mode, and restore concurrent inference after tool calls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Build Release
         if: ${{ runner.os != 'Windows' }}
-        run: SHARDS_BIN_PATH=bin/release shards build --release
+        run: SHARDS_BIN_PATH=bin/release shards --production build --release
 
       # Ah, Windows.
       - name: Setup release environment (Windows)
@@ -105,4 +105,4 @@ jobs:
         env:
           SHARDS_BIN_PATH: "bin/release"
         run: |
-          shards build --release
+          shards --production build --release

--- a/ops.yml
+++ b/ops.yml
@@ -3,7 +3,7 @@ dependencies:
     - crystal
     - node
   custom:
-    - shards
+    - shards check || shards install
     - cd webui && npm i && cd ..
 hooks:
   before:
@@ -15,7 +15,7 @@ actions:
     description: Build the Svelte-based web UI
     alias: bwui
   build-release:
-    command: ops build-webui && SHARDS_BIN_PATH=bin/release shards build $APP --release
+    command: ops build-webui && SHARDS_BIN_PATH=bin/release shards --production build $APP --release
     description: Build for release
     alias: br
   build-debug:

--- a/release_notes/v0.9.4-pre.md
+++ b/release_notes/v0.9.4-pre.md
@@ -1,3 +1,8 @@
+#### IMPROVEMENTS
+
+- In quiet mode, thinking / reasoning is shown in a mini 5-line scrolling region, and then erased to remove clutter.
+- Tool calling is now separated from the subsequent inference, which lets us run inference after tool calls concurrently
+- Use platform-specific terminal / console setup using latest `termify`.
 
 #### FIXES
 

--- a/shard.lock
+++ b/shard.lock
@@ -54,7 +54,7 @@ shards:
 
   termify:
     git: https://github.com/nogginly/termify.cr.git
-    version: 0.5.3
+    version: 0.6.0
 
   textseg:
     git: https://github.com/naqvis/uni_text_seg.git

--- a/shard.yml
+++ b/shard.yml
@@ -16,7 +16,7 @@ development_dependencies:
 dependencies:
   termify:
     github: nogginly/termify.cr
-    version: 0.5.3
+    version: 0.6.0
   liquid:
     github: amberframework/liquid.cr
     version: 1.0.0

--- a/src/enkaidu/console/renderer.cr
+++ b/src/enkaidu/console/renderer.cr
@@ -245,18 +245,26 @@ module Enkaidu::Console
       end
     end
 
+    @term_subscroller = Termify::ANSI::SubScroller.new(Termify.terminal, 5)
+
     def llm_text(text, reasoning : Bool, starting : Bool = false, ending : Bool = false)
       if streaming?
         if reasoning
           if quiet?
+            # Use a mini-scroll region in quiet mode, and then erase it.
             if starting
-              print fmt(:thinking_progress, "  Thinking  ")
-              @think_counter.reset
+              puts fmt(:thinking_content, REASONING_START)
+              @term_subscroller.start
             end
+            print fmt(:thinking_content, text)
             if ending
-              print "\r                          \r"
-            else
-              print "\b", @think_counter.spin
+              puts "", fmt(:thinking_content, REASONING_FINISH)
+              STDOUT.flush
+              sleep 100.milliseconds
+              @term_subscroller.stop(top: true)
+              print Termify::ANSI::Cursor.up(1)
+              print Termify::ANSI::Clear.screen(Termify::ANSI::Erase::After)
+              STDOUT.flush
             end
           else
             puts "", fmt(:thinking_content, REASONING_START) if starting
@@ -271,7 +279,7 @@ module Enkaidu::Console
       end
     end
 
-    REASONING_START  = "╭╶╶╶╶╶╶╶╶╶╶< reasoning >╶╶╶╶╶╶╶╶╶╶╶"
+    REASONING_START  = "╭╶╶╶╶╶╶╶╶╶╶< thinking >╶╶╶╶╶╶╶╶╶╶╶"
     REASONING_FINISH = "╰╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶"
 
     def llm_text_block(text, reasoning : Bool)

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -245,16 +245,32 @@ module Enkaidu
     # Perform tool calls and subsequent events repeatedly until
     # no more tool calls remain
     private def consume_tool_calls(tools)
-      # Cannot do this concurrently since tool calls can prompt user
-      # for input
       until tools.empty?
         calls = tools
         tools = [] of JSON::Any
         ix = 0
         prev_event = nil
-        chat.call_tools_and_ask calls do |event|
+        # Invoke the tool calls first since we
+        # cannot do this concurrently since tool calls can prompt user for input
+        calls = chat.call_tools_and_setup_ask(calls) do |event|
           m_process_and_record_ask_event(event, prev_event)
           prev_event = event
+        end
+        if calls.positive?
+          # Hand over to the LLM to process the tool call responses
+          # in fiber
+          ev_queue = queue_chat_request do |queue|
+            spawn do
+              chat.re_ask do |event|
+                queue << event
+                Fiber.yield
+              end
+            ensure
+              queue << {type: "DONE", content: JSON::Any.new(nil)}
+            end
+          end
+          # Process events in queue
+          gather_and_handle(ev_queue, tools)
         end
         detect_text_ending(nil, prev_event)
       end

--- a/src/llm/chat.cr
+++ b/src/llm/chat.cr
@@ -84,6 +84,10 @@ module LLM
 
     abstract def import(prompt : MCP::PromptResult, emit = false, & : ChatEvent ->) : Nil
 
+    # Invoke tool calls and return number of calls made; if positive call `re_ask` to
+    # hand call results to the models to process
+    abstract def call_tools_and_setup_ask(tool_calls : Array(JSON::Any), & : LLM::ChatEvent ->) : Int32
+
     # Resubmit current session as a query to get another answer
     abstract def re_ask(response_schema : ResponseSchema? = nil, & : ChatEvent ->) : Nil
 

--- a/src/llm/openai/chat.cr
+++ b/src/llm/openai/chat.cr
@@ -117,7 +117,9 @@ module LLM::OpenAI
       Message::ToolCall.new tool_call_id: id, name: tool.name, content: reply
     end
 
-    def call_tools_and_ask(tool_calls : Array(JSON::Any), & : LLM::ChatEvent ->) : Nil
+    # Invoke tool calls and return number of calls made; if positive call `re_ask` to
+    # hand call results to the models to process
+    def call_tools_and_setup_ask(tool_calls : Array(JSON::Any), & : LLM::ChatEvent ->) : Int32
       calls = 0
       tool_calls.each do |call|
         name = call.dig("function", "name").as_s
@@ -134,12 +136,7 @@ module LLM::OpenAI
         end
         calls += 1
       end
-
-      return unless calls.positive?
-
-      ask_post do |msg|
-        yield msg
-      end
+      calls
     end
 
     private def unknown_tool_call(tool_call : JSON::Any)

--- a/src/main.cr
+++ b/src/main.cr
@@ -1,3 +1,5 @@
+require "termify"
+
 require "./enkaidu/cli/*"
 require "./enkaidu/console/*"
 require "./enkaidu/wui/main"
@@ -8,7 +10,15 @@ module Enkaidu
     private getter opts : CLI::Options
     private getter console : Console::Renderer
 
+    private def setup_console
+      # Setup terminal and put it in VT mode (for platforms that need it)
+      term = Termify.terminal
+      term.setup_console
+      at_exit { term.restore_console }
+    end
+
     def initialize
+      setup_console
       @console = Console::Renderer.new
       @opts = CLI::Options.new(console)
 


### PR DESCRIPTION
### What?

- In quiet mode, thinking / reasoning is shown in a mini 5-line scrolling region, and then erased to remove clutter.
- Tool calling is now separated from the subsequent inference, which lets us run inference after tool calls concurrently
- Use platform-specific terminal / console setup using latest `termify`.

### Why?

- In quiet mode, thinking tool a long time and not knowing what was happening was not a good experience
- While tool calling needed to in main fiber, subsequent inference is a separate step and making it concurrent allows for better progress indication
