### PR TITLE
Add `exclude_past_reasoning` config across session or per model

### DIFF
--- a/release_notes/v0.9.4-pre.md
+++ b/release_notes/v0.9.4-pre.md
@@ -1,3 +1,15 @@
+#### NEW
+
+- The configuration has a new property `exclude_past_reasoning` that can be set in two ways.
+  - The config `session` supports `exclude_past_reasoning`, which by default is `false`, and when set affects all models across all forked / new sessions.
+  - The config `llm: ... model:` supports an optionsl `settings:` map which supports `exclude_past_reasoning`:
+    - It's `false` by default for all models
+    - When set to `true` affects chat turns in any session where that model is in use.
+- Excluding past reasoning affects all past response _when_ starting a new turn.
+  - Reasoning is preserved for LLM-initiated turns since the last user-initiated prompt until the next one by the user.
+  - When enabled, excluding past reasoning can reduce noise between turns.
+  - Some models like `gemma4*` recommend excluding past reasoning
+
 #### IMPROVEMENTS
 
 - In quiet mode, thinking / reasoning is shown in a mini 5-line scrolling region, and then erased to remove clutter.

--- a/src/enkaidu/config.cr
+++ b/src/enkaidu/config.cr
@@ -55,8 +55,14 @@ module Enkaidu
     class LLM < ConfigSerializable
       # Represents a Model within an LLM.
       class Model < ConfigSerializable
+        # Represents settings for a model
+        class Settings < ConfigSerializable
+          getter? exclude_past_reasoning = false
+        end
+
         getter name : String
         getter model : String
+        getter settings : Settings?
       end
 
       getter provider : String
@@ -75,6 +81,7 @@ module Enkaidu
     class Session < ConfigSerializable
       getter? streaming = false
       getter? quiet = false
+      getter? exclude_past_reasoning = false
       getter provider_type : String?
       getter model : String?
       getter input_history_file : String?
@@ -171,6 +178,22 @@ module Enkaidu
       else
         # no override, so use from profile
         @auto_load = profile_auto_load
+      end
+    end
+
+    # Use the actual model name (not the name we give it in our config) and provider type
+    # to find the LLM::Model object
+    def find_llm_model_by_actual?(provider_type : String, actual_model_name : String) : Config::LLM::Model?
+      llms.try &.each do |_, llm|
+        if llm.provider == provider_type
+          llm.models.try &.each do |model|
+            if model.model == actual_model_name
+              return model
+            end
+          end
+          # no more
+          break
+        end
       end
     end
 

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -87,6 +87,16 @@ module Enkaidu
       @renderer.streaming = chat.streaming?
     end
 
+    private def connection_provider_type
+      case @connection
+      when LLM::Ollama::Connection      then "ollama"
+      when LLM::AzureOpenAI::Connection then "azure_openai"
+      else
+        # Default because above subclass from the OpenAI one
+        "openai"
+      end
+    end
+
     # Create a new session "forked" from a given `Session` to create a duplicate session.
     def initialize(fork_from : Session, keep_tools = true, keep_prompts = true, keep_history = true, system_prompt_name = nil)
       @recorder = fork_from.recorder
@@ -98,7 +108,8 @@ module Enkaidu
       override_sys_prompt = if system_prompt_name
                               render_system_prompt(system_prompt_name)
                             end
-      @chat = setup_chat(override_sys_prompt, override_model_name: fork_from.chat.model)
+      @chat = setup_chat(override_system_prompt: override_sys_prompt,
+        override_model_name: fork_from.chat.model)
       chat.fork(fork_from.chat) if keep_history
 
       if keep_tools
@@ -115,6 +126,9 @@ module Enkaidu
       end
     end
 
+    # Keep track of config's LLM model so we can use settings when needed
+    private getter model_config : Config::LLM::Model?
+
     # Helper to setup the Chat's initial config
     private def setup_chat(override_system_prompt : String? = nil,
                            override_model_name : String? = nil)
@@ -122,11 +136,20 @@ module Enkaidu
         unless (m = override_model_name || opts.model_name).nil?
           with_model m
           renderer.info_with("INFO: Using model #{m}")
+
+          @model_config = opts.config.find_llm_model_by_actual?(connection_provider_type, m)
         end
         with_debug if opts.debug?
         with_streaming if opts.stream?
         with_system_message system_prompt(override_system_prompt)
       end
+    end
+
+    # Return based on session override, or model settings
+    private def exclude_past_reasoning?
+      opts.config.session.try(&.exclude_past_reasoning?) ||
+        @model_config.try(&.settings.try(&.exclude_past_reasoning?)) ||
+        false
     end
 
     # Load the selected LLM's environment variable values into
@@ -324,7 +347,8 @@ module Enkaidu
       report_time_taken(prefix: "Total ") do
         ev_queue = queue_chat_request do |queue|
           spawn do
-            chat.re_ask(response_schema: response_json_schema) do |event|
+            chat.re_ask(response_schema: response_json_schema,
+              exclude_reasoning_in_history: exclude_past_reasoning?) do |event|
               queue << event
               Fiber.yield
             end
@@ -357,7 +381,10 @@ module Enkaidu
         # Run the chat query concurrently
         ev_queue = queue_chat_request do |queue|
           spawn do
-            chat.ask(query, attach: attach, response_schema: response_json_schema) do |event|
+            chat.ask(query,
+              attach: attach,
+              response_schema: response_json_schema,
+              exclude_reasoning_in_history: exclude_past_reasoning?) do |event|
               queue << event
               Fiber.yield
             end

--- a/src/llm/chat.cr
+++ b/src/llm/chat.cr
@@ -89,12 +89,13 @@ module LLM
     abstract def call_tools_and_setup_ask(tool_calls : Array(JSON::Any), & : LLM::ChatEvent ->) : Int32
 
     # Resubmit current session as a query to get another answer
-    abstract def re_ask(response_schema : ResponseSchema? = nil, & : ChatEvent ->) : Nil
+    abstract def re_ask(response_schema : ResponseSchema? = nil, exclude_reasoning_in_history = false, & : ChatEvent ->) : Nil
 
     # Submit a query, with optional attachments and request for response as a JSON object by specifying a JSON schema.
     abstract def ask(content : String,
                      attach : ChatInclusions? = nil,
                      response_schema : ResponseSchema? = nil,
+                     exclude_reasoning_in_history = false,
                      & : ChatEvent ->) : Nil
 
     # Replace current session with a "fork" of the session from the given

--- a/src/llm/openai/chat.cr
+++ b/src/llm/openai/chat.cr
@@ -147,8 +147,10 @@ module LLM::OpenAI
       @history.import(prompt, emit) { |event| yield event }
     end
 
-    def re_ask(response_schema : ResponseSchema? = nil, & : ChatEvent ->) : Nil
-      ask_post(response_schema: response_schema) do |msg|
+    def re_ask(response_schema : ResponseSchema? = nil,
+               exclude_reasoning_in_history = false,
+               & : ChatEvent ->) : Nil
+      ask_post(response_schema, exclude_reasoning_in_history) do |msg|
         yield msg
       end
     end
@@ -156,15 +158,19 @@ module LLM::OpenAI
     def ask(content : String,
             attach : ChatInclusions? = nil,
             response_schema : ResponseSchema? = nil,
+            exclude_reasoning_in_history = false,
             & : ChatEvent ->) : Nil
       append_message Message::MultiContent.new(prompt: content, attach: attach)
 
-      ask_post(response_schema: response_schema) do |msg|
+      ask_post(response_schema, exclude_reasoning_in_history) do |msg|
         yield msg
       end
     end
 
-    private def ask_post(response_schema : ResponseSchema? = nil, & : LLM::ChatEvent ->) : Nil
+    private def ask_post(response_schema : ResponseSchema? = nil,
+                         exclude_reasoning_in_history = false,
+                         & : LLM::ChatEvent ->) : Nil
+      @history.exclude_past_reasoning if exclude_reasoning_in_history
       body = to_body(response_schema)
 
       yield({type: "debug/request", content: JSON.parse(body)}) if debug?

--- a/src/llm/openai/chat/history.cr
+++ b/src/llm/openai/chat/history.cr
@@ -60,6 +60,19 @@ module LLM::OpenAI
       nil
     end
 
+    # Mark all historical responses to exclude reasoning from now on
+    protected def exclude_past_reasoning
+      # Walk the messages in reverse, and break when we encounter
+      # message already excluding reasoning
+      @messages.reverse_each do |msg|
+        actual = msg.message
+        if actual.is_a? Message::Response
+          break unless actual.include_reasoning?
+          actual.include_reasoning = false
+        end
+      end
+    end
+
     private def tail_chat_messages(num = 1, &)
       return if num.zero?
 

--- a/src/llm/openai/chat/message.cr
+++ b/src/llm/openai/chat/message.cr
@@ -13,6 +13,22 @@ module LLM::OpenAI
 
     # Emit this message as one or more `ChatEvent` objects
     abstract def emit(& : ChatEvent ->) : Nil
+
+    # Used to encode message for sending to LLM. Can't use regular
+    # to_json since we need to handle some special cases for the protocol
+    # but we want to serialize whole entry for saving / restoring.
+    # This starts the object and calls `protocol_fields_to_json`.
+    # Do not override!
+    def to_protocol_json(builder : JSON::Builder)
+      builder.object do
+        protocol_fields_to_json(builder)
+      end
+    end
+
+    # Override this to add your fields after calling `super`
+    protected def protocol_fields_to_json(json : JSON::Builder)
+      json.field "role", role
+    end
   end
 end
 

--- a/src/llm/openai/chat/message/multi_content.cr
+++ b/src/llm/openai/chat/message/multi_content.cr
@@ -43,5 +43,16 @@ module LLM::OpenAI
         end
       end
     end
+
+    protected def protocol_fields_to_json(json : JSON::Builder)
+      super
+      json.field "content" do
+        json.array do
+          content.each do |item|
+            item.to_json(json)
+          end
+        end
+      end
+    end
   end
 end

--- a/src/llm/openai/chat/message/response.cr
+++ b/src/llm/openai/chat/message/response.cr
@@ -9,6 +9,9 @@ module LLM::OpenAI
     @[JSON::Field(ignore_serialize: ((reasoning = @reasoning).nil? || reasoning.empty?))]
     property reasoning : String?
 
+    # If `false` don't include reasoning when resending this message to the model
+    property? include_reasoning = true
+
     @[JSON::Field(ignore_serialize: ((toolcalls = @tool_calls).nil? || toolcalls.empty?))]
     property tool_calls : Array(JSON::Any)?
 
@@ -35,6 +38,19 @@ module LLM::OpenAI
           type:    "tool_call_requested",
           content: call,
         })
+      end
+    end
+
+    protected def protocol_fields_to_json(json : JSON::Builder)
+      super
+      if thoughts = @reasoning
+        if thoughts.presence && include_reasoning?
+          json.field "reasoning", thoughts
+        end
+      end
+      json.field "content", content
+      if (calls = @tool_calls) && !calls.empty?
+        json.field "tool_calls", calls
       end
     end
   end

--- a/src/llm/openai/chat/message/tool_call.cr
+++ b/src/llm/openai/chat/message/tool_call.cr
@@ -26,5 +26,12 @@ module LLM::OpenAI
         content: JSON.parse(body),
       })
     end
+
+    protected def protocol_fields_to_json(json : JSON::Builder)
+      super
+      json.field "tool_call_id", tool_call_id
+      json.field "name", name
+      json.field "content", content
+    end
   end
 end

--- a/src/llm/openai/converters.cr
+++ b/src/llm/openai/converters.cr
@@ -66,7 +66,8 @@ module LLM::OpenAI
               end
             end
             session.each_message do |msg|
-              msg.to_json(json)
+              # msg.to_json(json)
+              msg.to_protocol_json(json)
             end
           end
         end


### PR DESCRIPTION
### What?

- The configuration has a new property `exclude_past_reasoning` that can be set in two ways.
  - The config `session` supports `exclude_past_reasoning`, which by default is `false`, and when set affects all models across all forked / new sessions.
  - The config `llm: ... model:` supports an optionsl `settings:` map which supports `exclude_past_reasoning`:
    - It's `false` by default for all models
    - When set to `true` affects chat turns in any session where that model is in use.
- Excluding past reasoning affects all past response _when_ starting a new turn.
  - Reasoning is preserved for LLM-initiated turns since the last user-initiated prompt until the next one by the user.

### Why?

- When enabled, excluding past reasoning can reduce noise between turns.
- Some models like `gemma4*` recommend excluding past reasoning
