### PR TITLE
Set max height and overflow (scroll) for think in web UI

### DIFF
--- a/release_notes/v0.9.4-pre.md
+++ b/release_notes/v0.9.4-pre.md
@@ -15,6 +15,7 @@
 - In quiet mode, thinking / reasoning is shown in a mini 5-line scrolling region, and then erased to remove clutter.
 - Tool calling is now separated from the subsequent inference, which lets us run inference after tool calls concurrently
 - Use platform-specific terminal / console setup using latest `termify`.
+- Web UI sets a maximum height and enables scrolling for think/reasoning content.
 
 #### FIXES
 

--- a/webui/src/lib/AsstThinkCard.svelte
+++ b/webui/src/lib/AsstThinkCard.svelte
@@ -17,7 +17,7 @@
       Thinking
     </div>
     <div
-      class="collapse-content text-base ms-6 ps-2 border-l-2 border-l-gray-400"
+      class="collapse-content text-base ms-6 ps-2 border-l-2 border-l-gray-400 max-h-40 overflow-y-scroll"
     >
       <Markdown content={message} add_class="text-sm" />
     </div>


### PR DESCRIPTION
### What?

- Web UI sets a maximum height and enables scrolling for think/reasoning content.

### Why?

- This prevents long thinking responses from overwhelming the screen when think sections are expanded.