### PR TITLE
Add think effort config to model settings

### DIFF
--- a/release_notes/v0.9.5.md
+++ b/release_notes/v0.9.5.md
@@ -1,8 +1,8 @@
 #### NEW
 
 - Added `/think [none|low|medium|high|default]` command to control the reasoning effort.
+- Support `think: ...` setting when defining models in `enkaidu.yml`; default is `default` for model.
 
 #### DEVELOPMENT
 
 - Added `ops install-debug` action which uses new `bake_webui_dist` compile-time flag to build and locally install debug build of Enkaidu
-

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: enkaidu
-version: 0.9.5-pre
+version: 0.9.5
 license: MPL-2.0
 description: Command line tool that can use local and remote AI models to assist
   with local editing and refinement tasks.

--- a/src/enkaidu/config.cr
+++ b/src/enkaidu/config.cr
@@ -1,5 +1,6 @@
 require "./config_serializable"
 require "../llm/function"
+require "../llm/chat"
 
 module Enkaidu
   # Config parsing error
@@ -58,6 +59,7 @@ module Enkaidu
         # Represents settings for a model
         class Settings < ConfigSerializable
           getter? exclude_past_reasoning = false
+          getter think = ::LLM::Reasoning::Default
         end
 
         getter name : String

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -142,6 +142,10 @@ module Enkaidu
         with_debug if opts.debug?
         with_streaming if opts.stream?
         with_system_message system_prompt(override_system_prompt)
+
+        if effort = @model_config.try(&.settings.try(&.think))
+          with_reasoning(effort)
+        end
       end
     end
 

--- a/src/enkaidu/slash/think.cr
+++ b/src/enkaidu/slash/think.cr
@@ -6,9 +6,8 @@ module Enkaidu::Slash
 
     THINK_EFFORT = ["none", "low", "medium", "high", "default"]
 
-    HELP_BRIEF = "`#{NAME} [#{THINK_EFFORT.join(" or ")}]` - Include attachments for next query"
-    # HELP_BRIEF = "`#{NAME} [none|low|medium|high|default]` - Request thinking effort, or show current effort"
-    HELP = <<-HELP1
+    HELP_BRIEF = "`#{NAME} [#{THINK_EFFORT.join(" or ")}]` - Request thinking effort, or show current effort"
+    HELP       = <<-HELP1
     #{HELP_BRIEF}
     - If `none`, disables thinking / reasoning if the model supports it
     - If `low` or `medium` or `high`, enables thinking / reasoning, though granularity depends on the model


### PR DESCRIPTION
### What?

- Added `/think [none|low|medium|high|default]` command to control the reasoning effort.
- Support `think: ...` setting when defining models in `enkaidu.yml`; default is `default` for model.

### Why?

- Model providers, and many models, support configuring the "thinking" effort. 
- Being able to control this can be useful when using models for different tasks.
