### PR TITLE
Fix race condition

### DIFF
--- a/release_notes/v0.9.6.md
+++ b/release_notes/v0.9.6.md
@@ -1,0 +1,4 @@
+#### FIX
+
+- Fixes two race conditions, one that exposed the other when used with fast-running LLMs.
+  - The benefit is worth releasing on its own.

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: enkaidu
-version: 0.9.5
+version: 0.9.6
 license: MPL-2.0
 description: Command line tool that can use local and remote AI models to assist
   with local editing and refinement tasks.

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -225,7 +225,8 @@ module Enkaidu
 
     # Process the given event and yield tool call if any
     private def process_event(event, prev_event, &) : Nil
-      return unless type = event["type"]
+      type = event["type"]
+      return if type.starts_with?("debug")
 
       # Handle text/reasoning ending detection first
       detect_text_ending(type, prev_event)
@@ -269,6 +270,8 @@ module Enkaidu
       renderer.time_elapsed(tm_taken, prefix)
     end
 
+    private SPAWN_DONE = {type: "<ESSFINI>", content: JSON::Any.new(nil)}
+
     # Perform tool calls and subsequent events repeatedly until
     # no more tool calls remain
     private def consume_tool_calls(tools)
@@ -281,7 +284,7 @@ module Enkaidu
         # cannot do this concurrently since tool calls can prompt user for input
         calls = chat.call_tools_and_setup_ask(calls) do |event|
           m_process_and_record_ask_event(event, prev_event)
-          prev_event = event
+          prev_event = event unless event["type"].starts_with?("debug")
         end
         if calls.positive?
           # Hand over to the LLM to process the tool call responses
@@ -293,7 +296,7 @@ module Enkaidu
                 Fiber.yield
               end
             ensure
-              queue << {type: "DONE", content: JSON::Any.new(nil)}
+              queue << SPAWN_DONE
             end
           end
           # Process events in queue
@@ -325,11 +328,11 @@ module Enkaidu
       prev_event = nil
       loop do
         if event = queue.shift?
-          break if event["type"].upcase == "DONE"
+          break if event == SPAWN_DONE
 
           STDERR.print "\r\e[K" unless streaming?
           m_process_and_record_ask_event(event, prev_event)
-          prev_event = event
+          prev_event = event unless event["type"].starts_with?("debug")
         else
           if streaming?
             sleep(10.milliseconds)
@@ -357,7 +360,7 @@ module Enkaidu
               Fiber.yield
             end
           ensure
-            queue << {type: "DONE", content: JSON::Any.new(nil)}
+            queue << SPAWN_DONE
           end
         end
         # Process events in queue
@@ -393,7 +396,7 @@ module Enkaidu
               Fiber.yield
             end
           ensure
-            queue << {type: "DONE", content: JSON::Any.new(nil)}
+            queue << SPAWN_DONE
           end
         end
         # Process events in queue

--- a/src/llm/connection.cr
+++ b/src/llm/connection.cr
@@ -1,6 +1,6 @@
 require "http/client"
 require "uri"
-
+require "sync/exclusive"
 require "./chat"
 
 module LLM
@@ -9,19 +9,24 @@ module LLM
   abstract class Connection
     protected property model : String? = nil
 
+    # Keep client exclusive to avoid concurrent calls to same client
+    @sync : Sync::Exclusive(HTTP::Client)
+
     def initialize
-      @client = HTTP::Client.new(URI.parse(url))
+      @sync = Sync::Exclusive.new(HTTP::Client.new(URI.parse(url)))
     end
 
     protected def post_and_stream(body, &)
-      if TRACE
-        STDERR.puts ">>> POST #{path}" if TRACE
-        STDERR.puts ">>> #{headers}" if TRACE
-      end
-      @client.post(path, headers,
-        body: body) do |resp|
-        yield resp
-        resp # Always return the response at end of streaming handler block
+      @sync.lock do |client|
+        if TRACE
+          STDERR.puts ">>> POST #{path}" if TRACE
+          STDERR.puts ">>> #{headers}" if TRACE
+        end
+        client.post(path, headers,
+          body: body) do |resp|
+          yield resp
+          resp # Always return the response at end of streaming handler block
+        end
       end
     end
 


### PR DESCRIPTION
## Root cause

Two race condition opportunities:
1. Session was using "DONE" as a marker but LLM was using "done" and this led to premature exits when handling events from a _spawned_ fiber running the connection protocol
2. Connection could be used to post requests concurrently, which was happening due to race condition above

## Fix

1. Use a unique marker in Enkaidu session to identify event of events from a spawned fiber
2. Make connection's client use exclusive to avoid concurrent calling
