### PR TITLE
Add enforced system config, read-only mode, and more

### DIFF
--- a/release_notes/v0.9.7.md
+++ b/release_notes/v0.9.7.md
@@ -1,11 +1,11 @@
 
 #### EARLY ACCESS
 
-- Add `gemini_openai` LLM provider type that uses the endpoint definition from [Open AI compatibility doc](https://ai.google.dev/gemini-api/docs/openai).
-  - Expects API key via `GEMINI_API_KEY` environment variable.
+- Add `google_ai_openai` LLM provider type for Google AI Studio, using the endpoint definition from [Open AI compatibility doc](https://ai.google.dev/gemini-api/docs/openai).
+  - Expects API key via `GOOGLE_AI_API_KEY` environment variable.
   - Since current endpoint is in beta and may change over time, the following environment variables can be used to override built-in defaults in the future.
-    - `GEMINI_OPENAI_ENDPOINT` to replace default: `https://generativelanguage.googleapis.com`
-    - `GEMINI_OPENAI_CHAT_PATH` to replace default: `/v1beta/openai/chat/completions`
+    - `GOOGLE_AI_ENDPOINT` to replace default: `https://generativelanguage.googleapis.com`
+    - `GOOGLE_AI_OPENAI_CHAT_PATH` to replace default: `/v1beta/openai/chat/completions`
 
 #### NEW
 

--- a/release_notes/v0.9.7.md
+++ b/release_notes/v0.9.7.md
@@ -17,8 +17,8 @@
   - Otherwise, it looks for `/etc/enkaidu.yml`
   - If found, it refuses to load any local / profile config files, enforcing system config ONLY
 - Add session configuration properties to allow / disallow system tools:
-  - `allow_tool_discovery:` default to `true` but can be set to `false` to disallow tool discovery / install by AI models
-  - `allow_sub_agents:` defaults to `true`  but can be set to `false` to disallow spawning sub-agents by AI models
+  - `allow_tool_discovery:` Can be set to `true` to allow tool discovery / install by AI models; `false` by default.
+  - `allow_sub_agents:` Can be set to `true` to disallow spawning sub-agents by AI models; `false` by default.
 
 #### IMPROVEMENTS
 

--- a/release_notes/v0.9.7.md
+++ b/release_notes/v0.9.7.md
@@ -12,7 +12,7 @@
 
 - Streaming mode is enabled by default!
 - All built-in tools declare their side-effects
-- List of active tools includes side-effects and summary.
+- Active tools and available toolsets are listed in tables, and includes each tool's side-effects and summary.
 
 #### FIXES
 

--- a/release_notes/v0.9.7.md
+++ b/release_notes/v0.9.7.md
@@ -7,6 +7,9 @@
   - For Windows, it looks for `C:\Windows\System32\drivers\etc\hosts\enkaidu.yml`
   - Otherwise, it looks for `/etc/enkaidu.yml`
   - If found, it refuses to load any local / profile config files, enforcing system config ONLY
+- Add session configuration properties to allow / disallow system tools:
+  - `allow_tool_discovery:` default to `true` but can be set to `false` to disallow tool discovery / install by AI models
+  - `allow_sub_agents:` defaults to `true`  but can be set to `false` to disallow spawning sub-agents by AI models
 
 #### IMPROVEMENTS
 

--- a/release_notes/v0.9.7.md
+++ b/release_notes/v0.9.7.md
@@ -14,10 +14,6 @@
 
 - Deprecating `-S`/`--streaming` flags, they do nothing; will be removed.
 
-#### FIXES
-
-- Fixed the `str_replace_in_text_file`, `str_replace_lines_in_text_file`, `str_insert_in_text_file`, and `str_regex_replace_in_text_file` (also renamed) tools to not allow edits to file in the `.deleted_files/` folder.
-
 #### UNDER THE HOOD
 
 - Define `LLM::Function::SideEffects` flags that every function / tool must declare. This allows Enkaidu to identify and filter by side-effects for read-only mode.

--- a/release_notes/v0.9.7.md
+++ b/release_notes/v0.9.7.md
@@ -40,3 +40,5 @@
 #### UNDER THE HOOD
 
 - Define `LLM::Function::SideEffects` flags that every function / tool must declare. This allows Enkaidu to identify and filter by side-effects for read-only mode.
+- Update Web UI's `node` package dependencies.
+- Update Enkaidu's `shards` dependencies

--- a/release_notes/v0.9.7.md
+++ b/release_notes/v0.9.7.md
@@ -1,7 +1,7 @@
 
 #### EARLY ACCESS
 
-- Add `google_ai_openai` LLM provider type for Google AI Studio, using the endpoint definition from [Open AI compatibility doc](https://ai.google.dev/gemini-api/docs/openai).
+- Add `google_ai_studio` LLM provider type for Google AI Studio, using the endpoint definition from [Open AI compatibility doc](https://ai.google.dev/gemini-api/docs/openai).
   - Expects API key via `GOOGLE_AI_API_KEY` environment variable.
   - Since current endpoint is in beta and may change over time, the following environment variables can be used to override built-in defaults in the future.
     - `GOOGLE_AI_ENDPOINT` to replace default: `https://generativelanguage.googleapis.com`

--- a/release_notes/v0.9.7.md
+++ b/release_notes/v0.9.7.md
@@ -1,3 +1,12 @@
+
+#### EARLY ACCESS
+
+- Add `gemini_openai` LLM provider type that uses the endpoint definition from [Open AI compatibility doc](https://ai.google.dev/gemini-api/docs/openai).
+  - Expects API key via `GEMINI_API_KEY` environment variable.
+  - Since current endpoint is in beta and may change over time, the following environment variables can be used to override built-in defaults in the future.
+    - `GEMINI_OPENAI_ENDPOINT` to replace default: `https://generativelanguage.googleapis.com`
+    - `GEMINI_OPENAI_CHAT_PATH` to replace default: `/v1beta/openai/chat/completions`
+
 #### NEW
 
 - Add read-only mode, configurable as follows, that restricts all built-tools to only those with read-only side-effects

--- a/release_notes/v0.9.7.md
+++ b/release_notes/v0.9.7.md
@@ -1,0 +1,23 @@
+#### NEW
+
+- Add read-only mode, configurable as follows, that restricts all built-tools to only those with read-only side-effects
+  - Add `readonly: true | false` to `session:` settings on Config.
+  - Support `--readonly` flag that puts Enkaidu into readonly mode
+
+#### IMPROVEMENTS
+
+- Streaming mode is enabled by default!
+- All built-in tools declare their side-effects
+- List of active tools includes side-effects and summary.
+
+#### COMPATIBILITY
+
+- Deprecating `-S`/`--streaming` flags, they do nothing; will be removed.
+
+#### FIXES
+
+- Fixed the `str_replace_in_text_file`, `str_replace_lines_in_text_file`, `str_insert_in_text_file`, and `str_regex_replace_in_text_file` (also renamed) tools to not allow edits to file in the `.deleted_files/` folder.
+
+#### UNDER THE HOOD
+
+- Define `LLM::Function::SideEffects` flags that every function / tool must declare. This allows Enkaidu to identify and filter by side-effects for read-only mode.

--- a/release_notes/v0.9.7.md
+++ b/release_notes/v0.9.7.md
@@ -3,12 +3,20 @@
 - Add read-only mode, configurable as follows, that restricts all built-tools to only those with read-only side-effects
   - Add `readonly: true | false` to `session:` settings on Config.
   - Support `--readonly` flag that puts Enkaidu into readonly mode
+- Add enforced system configuration mode where Enkaidu looks at a platform specific system location for `enkaidu.yml`
+  - For Windows, it looks for `C:\Windows\System32\drivers\etc\hosts\enkaidu.yml`
+  - Otherwise, it looks for `/etc/enkaidu.yml`
+  - If found, it refuses to load any local / profile config files, enforcing system config ONLY
 
 #### IMPROVEMENTS
 
 - Streaming mode is enabled by default!
 - All built-in tools declare their side-effects
 - List of active tools includes side-effects and summary.
+
+#### FIXES
+
+- Fix a streaming text rendering edge case where end of text detection was missed for last line without newline
 
 #### COMPATIBILITY
 

--- a/release_notes/v0.9.7.md
+++ b/release_notes/v0.9.7.md
@@ -13,6 +13,8 @@
 - Streaming mode is enabled by default!
 - All built-in tools declare their side-effects
 - Active tools and available toolsets are listed in tables, and includes each tool's side-effects and summary.
+- Changed `find_files` tool to require `expression` _and_ `path` parameters. This better matches how `find` works, which models understand well.
+- Tweaked `read_text_file` to return an error indicating path was not a file. Some small models keep trying to "read" a directory over and over again.
 
 #### FIXES
 

--- a/release_notes/v0.9.7.md
+++ b/release_notes/v0.9.7.md
@@ -15,6 +15,7 @@
 - Active tools and available toolsets are listed in tables, and includes each tool's side-effects and summary.
 - Changed `find_files` tool to require `expression` _and_ `path` parameters. This better matches how `find` works, which models understand well.
 - Tweaked `read_text_file` to return an error indicating path was not a file. Some small models keep trying to "read" a directory over and over again.
+- Report specific error when a model makes a tool call with blank tool / function name. (Yes, some models do this.)
 
 #### FIXES
 

--- a/shard.lock
+++ b/shard.lock
@@ -26,7 +26,7 @@ shards:
 
   json-schema:
     git: https://github.com/spider-gazelle/json-schema.git
-    version: 1.3.2
+    version: 1.3.3
 
   liquid:
     git: https://github.com/amberframework/liquid.cr.git

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: enkaidu
-version: 0.9.6
+version: 0.9.7-pre
 license: MPL-2.0
 description: Command line tool that can use local and remote AI models to assist
   with local editing and refinement tasks.

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: enkaidu
-version: 0.9.7-pre
+version: 0.9.7
 license: MPL-2.0
 description: Command line tool that can use local and remote AI models to assist
   with local editing and refinement tasks.

--- a/shard.yml
+++ b/shard.yml
@@ -22,7 +22,7 @@ dependencies:
     version: 1.0.0
   json-schema:
     github: spider-gazelle/json-schema
-    version: 1.3.2
+    version: 1.3.3
   reply:
     github: I3oris/reply
     version: 0.4.0

--- a/spec/unit/tools/file_management/find_files_tool_spec.cr
+++ b/spec/unit/tools/file_management/find_files_tool_spec.cr
@@ -29,15 +29,15 @@ Spectator.describe Tools::FileManagement::FindFilesTool do
     if hash_val
       err = hash_val["error"]?
       if err
-        return { success: false, data: parsed, error_msg: err.as_s }
+        return {success: false, data: parsed, error_msg: err.as_s}
       end
     end
-     { success: true, data: parsed, error_msg: nil }
+    {success: true, data: parsed, error_msg: nil}
   end
 
-   # -------------------------------------------------
-    # Successful glob matching scenarios
-    # -------------------------------------------------
+  # -------------------------------------------------
+  # Successful glob matching scenarios
+  # -------------------------------------------------
 
   context "finds files matching a simple glob pattern" do
     let(:file_a) { File.join(temp_dir, "file_a.txt") }
@@ -52,9 +52,9 @@ Spectator.describe Tools::FileManagement::FindFilesTool do
 
     it "returns matching file paths as a JSON array" do
       args = {
-          "expression" => "*.txt",
-          "path"          => temp_dir,
-        }
+        "expression" => "*.txt",
+        "path"       => temp_dir,
+      }
 
       result_json = runner.execute(JSON.parse(args.to_json))
       result = parse_run_result(result_json)
@@ -75,9 +75,9 @@ Spectator.describe Tools::FileManagement::FindFilesTool do
 
     it "returns matching files when using recursive glob" do
       args = {
-          "expression" => "**/*",
-          "path"          => temp_dir,
-        }
+        "expression" => "**/*",
+        "path"       => temp_dir,
+      }
 
       result_json = runner.execute(JSON.parse(args.to_json))
       result = parse_run_result(result_json)
@@ -90,9 +90,9 @@ Spectator.describe Tools::FileManagement::FindFilesTool do
     end
   end
 
-   # -------------------------------------------------
-    # Sorting scenarios
-    # -------------------------------------------------
+  # -------------------------------------------------
+  # Sorting scenarios
+  # -------------------------------------------------
 
   context "applies sorting by default" do
     let(:file_c) { File.join(temp_dir, "c.txt") }
@@ -107,9 +107,9 @@ Spectator.describe Tools::FileManagement::FindFilesTool do
 
     it "returns files in sorted order by default" do
       args = {
-          "expression" => "*.txt",
-          "path"          => temp_dir,
-        }
+        "expression" => "*.txt",
+        "path"       => temp_dir,
+      }
 
       result_json = runner.execute(JSON.parse(args.to_json))
       result = parse_run_result(result_json)
@@ -131,10 +131,10 @@ Spectator.describe Tools::FileManagement::FindFilesTool do
 
     it "returns files in whatever order the glob provides" do
       args = {
-          "expression" => "*.txt",
-          "path"          => temp_dir,
-          "sort"          => false,
-        }
+        "expression" => "*.txt",
+        "path"       => temp_dir,
+        "sort"       => false,
+      }
 
       result_json = runner.execute(JSON.parse(args.to_json))
       result = parse_run_result(result_json)
@@ -144,13 +144,13 @@ Spectator.describe Tools::FileManagement::FindFilesTool do
     end
   end
 
-   # -------------------------------------------------
-    # Max limit scenarios
-    # -------------------------------------------------
+  # -------------------------------------------------
+  # Max limit scenarios
+  # -------------------------------------------------
 
   context "respects the max parameter" do
     let(:files) do
-       (1..10).map { |i| File.join(temp_dir, "file_#{i}.txt") }
+      (1..10).map { |i| File.join(temp_dir, "file_#{i}.txt") }
     end
 
     before do
@@ -159,10 +159,10 @@ Spectator.describe Tools::FileManagement::FindFilesTool do
 
     it "limits results to the specified max count" do
       args = {
-          "expression" => "*.txt",
-          "path"          => temp_dir,
-          "max"           => 3,
-        }
+        "expression" => "*.txt",
+        "path"       => temp_dir,
+        "max"        => 3,
+      }
 
       result_json = runner.execute(JSON.parse(args.to_json))
       result = parse_run_result(result_json)
@@ -173,10 +173,10 @@ Spectator.describe Tools::FileManagement::FindFilesTool do
 
     it "returns all matches when max exceeds the number of matches" do
       args = {
-          "expression" => "*.txt",
-          "path"          => temp_dir,
-          "max"           => 999,
-        }
+        "expression" => "*.txt",
+        "path"       => temp_dir,
+        "max"        => 999,
+      }
 
       result_json = runner.execute(JSON.parse(args.to_json))
       result = parse_run_result(result_json)
@@ -186,57 +186,55 @@ Spectator.describe Tools::FileManagement::FindFilesTool do
     end
   end
 
-   # -------------------------------------------------
-    # Default path scenarios
-    # -------------------------------------------------
+  # -------------------------------------------------
+  # Default path scenarios
+  # -------------------------------------------------
 
-  context "uses '.' as the default path" do
+  context "requires path in all requests" do
     before do
       File.write(File.join(temp_dir, "found.txt"), "yes")
     end
 
-    it "works when path is not provided" do
+    it "fails when path is not provided" do
       Dir.cd(temp_dir) do
         args = {
-            "expression" => "*.txt",
-          }
+          "expression" => "*.txt",
+        }
 
         result_json = runner.execute(JSON.parse(args.to_json))
         result = parse_run_result(result_json)
 
-        expect(result[:success]).to be_true
-        expect(result[:data].as_a.size.to_i).to eq(1)
+        expect(result[:success]).to be_false
       end
     end
 
-    it "treats empty string path as '.'" do
+    it "fails on empty string path" do
       Dir.cd(temp_dir) do
         args = {
-            "expression" => "*.txt",
-            "path"          => "",
-          }
+          "expression" => "*.txt",
+          "path"       => "",
+        }
 
         result_json = runner.execute(JSON.parse(args.to_json))
         result = parse_run_result(result_json)
 
-        expect(result[:success]).to be_true
-        expect(result[:data].as_a.size.to_i).to eq(1)
+        expect(result[:success]).to be_false
       end
     end
   end
 
-   # -------------------------------------------------
-    # Security scenarios
-    # -------------------------------------------------
+  # -------------------------------------------------
+  # Security scenarios
+  # -------------------------------------------------
 
   context "blocks paths resolved outside the current directory" do
     let(:outside_path) { File.tempname("_outside.txt") }
 
     it "returns an error when the glob resolves outside" do
       args = {
-          "expression" => "*",
-          "path"          => outside_path,
-        }
+        "expression" => "*",
+        "path"       => outside_path,
+      }
 
       result_json = runner.execute(JSON.parse(args.to_json))
       result = parse_run_result(result_json)
@@ -254,9 +252,9 @@ Spectator.describe Tools::FileManagement::FindFilesTool do
 
     it "returns an error when pattern contains ../" do
       args = {
-          "expression" => "../../../etc/*.txt",
-          "path"          => safe_dir,
-        }
+        "expression" => "../../../etc/*.txt",
+        "path"       => safe_dir,
+      }
 
       result_json = runner.execute(JSON.parse(args.to_json))
       result = parse_run_result(result_json)
@@ -268,9 +266,9 @@ Spectator.describe Tools::FileManagement::FindFilesTool do
 
     it "returns an error when pattern contains /.." do
       args = {
-          "expression" => "../..",
-          "path"          => safe_dir,
-        }
+        "expression" => "../..",
+        "path"       => safe_dir,
+      }
 
       result_json = runner.execute(JSON.parse(args.to_json))
       result = parse_run_result(result_json)
@@ -281,9 +279,9 @@ Spectator.describe Tools::FileManagement::FindFilesTool do
     end
   end
 
-   # -------------------------------------------------
-    # Error handling scenarios
-    # -------------------------------------------------
+  # -------------------------------------------------
+  # Error handling scenarios
+  # -------------------------------------------------
 
   context "fails when expression is not provided" do
     it "returns an error" do
@@ -301,9 +299,9 @@ Spectator.describe Tools::FileManagement::FindFilesTool do
   context "handles invalid glob patterns gracefully" do
     it "returns an error when the glob contains invalid syntax" do
       args = {
-          "expression" => "[invalid",
-          "path"          => temp_dir,
-        }
+        "expression" => "[invalid",
+        "path"       => temp_dir,
+      }
 
       result_json = runner.execute(JSON.parse(args.to_json))
       result = parse_run_result(result_json)
@@ -317,9 +315,9 @@ Spectator.describe Tools::FileManagement::FindFilesTool do
   context "returns empty results when no files match" do
     it "succeeds with an empty JSON array" do
       args = {
-          "expression" => "*.xyz_nonexistent",
-          "path"          => temp_dir,
-        }
+        "expression" => "*.xyz_nonexistent",
+        "path"       => temp_dir,
+      }
 
       result_json = runner.execute(JSON.parse(args.to_json))
       result = parse_run_result(result_json)

--- a/spec/unit/tools/text_editing/read_text_file_tool_spec.cr
+++ b/spec/unit/tools/text_editing/read_text_file_tool_spec.cr
@@ -119,7 +119,7 @@ Spectator.describe Tools::TextEditing::ReadTextFileTool do
       result = JSON.parse(result_json).as_h
 
       expect(result["error"]).not_to be_nil
-      expect(result["error"]).to match(/The specified file 'nonexistent.txt' does not exist/)
+      expect(result["error"]).to match(/The path 'nonexistent.txt' does not exist/)
     end
   end
 

--- a/src/enkaidu/cli/main.cr
+++ b/src/enkaidu/cli/main.cr
@@ -136,8 +136,10 @@ module Enkaidu::CLI
       while !done?
         show_query_prompt
         if q = reader.read_next
-          runtime.execute_query(q) do |runtime_event|
-            handle_runtime_event(runtime_event)
+          unless q.blank?
+            runtime.execute_query(q) do |runtime_event|
+              handle_runtime_event(runtime_event)
+            end
           end
         else
           @done = true

--- a/src/enkaidu/cli/main.cr
+++ b/src/enkaidu/cli/main.cr
@@ -114,6 +114,7 @@ module Enkaidu::CLI
       depth = stack.depth
 
       String.build do |str|
+        str << "(R/o) " if session.readonly?
         str << '@' << stack.name
         str << ':' << depth if depth > 1
       end

--- a/src/enkaidu/cli/options.cr
+++ b/src/enkaidu/cli/options.cr
@@ -5,6 +5,7 @@ require "../config"
 require "../env"
 
 require "./trace_http"
+require "./system_enforcement"
 
 module Enkaidu
   module CLI
@@ -47,7 +48,11 @@ module Enkaidu
         @config = load_config || empty_config
         @profile = Env::Profile.new(Env::CURRENT_DIR, console, quiet?)
         if profile_config = profile.config
-          config.merge_profile_config(profile_config, console)
+          if Enkaidu.enforce_system_config?
+            error_and_exit_with "FATAL: Profile config should not have loaded since system config enforced. Report it please.", @opts
+          else
+            config.merge_profile_config(profile_config, console)
+          end
         end
 
         check_config_for_defaults
@@ -223,14 +228,27 @@ module Enkaidu
       end
 
       # Find and load config file,
-      # - starting with the specific path,
+      # - start by looking for an "enforced" system config file
+      # - next if a config file was specified via command,
       # - then the current directory, and
       # - finally the $HOME directory.
       private def load_config : Config?
-        if file = @options[:config_file]? ||
+        if file = Enkaidu.enforced_system_config_file ||
+                  @options[:config_file]? ||
                   Config.find_config_file(Env::CURRENT_DIR) ||
                   Config.find_config_file(Env::HOME_DIR)
           parse_config_file(file)
+        end
+        if Enkaidu.enforce_system_config?
+          if @options[:config_file]?
+            console.warning_with "WARN: Ignorning specified config! System config is enforced."
+          elsif Config.find_config_file(Env::CURRENT_DIR)
+            console.warning_with "WARN: Ignorning current directory config! System config is enforced."
+          elsif Config.find_config_file(Env::HOME_DIR)
+            console.warning_with "WARN: Ignorning home directory config! System config is enforced."
+          else
+            console.info_with "INFO: System config is enforced."
+          end
         end
       rescue IO::Error
         # If we fail to find default config file, it's OK.

--- a/src/enkaidu/cli/options.cr
+++ b/src/enkaidu/cli/options.cr
@@ -97,7 +97,7 @@ module Enkaidu
         MODEL
 
         parser.on("--provider=TYPE", "-p TYPE",
-          "If needed, one of \"azure_openai\", \"openai\", or \"ollama\".") do |type|
+          "If needed, one of provide types listed below.") do |type|
           @provider_type = type
           add(:provider_type, type)
         end
@@ -107,11 +107,15 @@ module Enkaidu
               If using a provider, different types depend on different environment
               variables.
 
-              ollama        OLLAMA_ENDPOINT (defaults to http://localhost:11434)
-              openai        OPENAI_MODEL, OPENAI_API_KEY,
+              ollama          OLLAMA_ENDPOINT (defaults to http://localhost:11434)
+              openai          OPENAI_MODEL, OPENAI_API_KEY,
                                     OPENAI_ENDPOINT (defaults to https://api.openai.com)
-              azure_openai  AZURE_OPENAI_MODEL, AZURE_OPENAI_ENDPOINT,
+              azure_openai    AZURE_OPENAI_MODEL, AZURE_OPENAI_ENDPOINT,
                                     AZURE_OPENAI_API_KEY, AZURE_OPENAI_API_VER
+
+              (Early access)
+              gemini_openai   GEMINI_API_KEY (required), GEMINI_OPENAI_ENDPOINT,
+                                    GEMINI_OPENAI_CHAT_PATH
       PROVIDER
       end
 

--- a/src/enkaidu/cli/options.cr
+++ b/src/enkaidu/cli/options.cr
@@ -251,9 +251,9 @@ module Enkaidu
                   @options[:config_file]? ||
                   Config.find_config_file(Env::CURRENT_DIR) ||
                   Config.find_config_file(Env::HOME_DIR)
+          report_enforce_system_config_override
           parse_config_file(file)
         end
-        report_enforce_system_config_override
       rescue IO::Error
         # If we fail to find default config file, it's OK.
         if @options[:config_file]?

--- a/src/enkaidu/cli/options.cr
+++ b/src/enkaidu/cli/options.cr
@@ -20,6 +20,7 @@ module Enkaidu
       getter? trace_mcp = false
       getter? trace_http = true
       getter? webui = false
+      getter? readonly = false
 
       getter recorder_file : IO? = nil
       getter profile : Env::Profile
@@ -70,7 +71,7 @@ module Enkaidu
           @model_name = name
           add(:model, name)
         end
-        parser.on("--streaming", "-S", "Enable streaming mode") do
+        parser.on("--streaming", "-S", "IGNORED; streaming is enabled by default; disable via config.") do
           @stream = true
           add(:stream, true)
         end
@@ -78,13 +79,17 @@ module Enkaidu
           @quiet = true
           add(:quiet, true)
         end
+        parser.on("--readonly", "Enable readonly mode; this disables all tools that can modify files / file system.") do
+          @readonly = true
+          add(:readonly, true)
+        end
 
         parser.separator <<-MODEL
 
               The model name can be one defined in the config file. Otherwise
               also specify the provider type using the '--provider' option.
 
-      MODEL
+        MODEL
 
         parser.on("--provider=TYPE", "-p TYPE",
           "If needed, one of \"azure_openai\", \"openai\", or \"ollama\".") do |type|
@@ -180,6 +185,7 @@ module Enkaidu
           @model_name = session_opts.model if model_name.nil?
           @stream = session_opts.streaming? unless @options.has_key?(:stream)
           @quiet = session_opts.quiet? unless @options.has_key?(:quiet)
+          @readonly = session_opts.readonly? unless @options.has_key?(:readonly)
         end
 
         return unless model_name && provider_type.nil?

--- a/src/enkaidu/cli/options.cr
+++ b/src/enkaidu/cli/options.cr
@@ -227,6 +227,20 @@ module Enkaidu
         config
       end
 
+      private def report_enforce_system_config_override
+        if Enkaidu.enforce_system_config?
+          if @options[:config_file]?
+            console.warning_with "WARN: Ignorning specified config! System config is enforced."
+          elsif Config.find_config_file(Env::CURRENT_DIR)
+            console.warning_with "WARN: Ignorning current directory config! System config is enforced."
+          elsif Config.find_config_file(Env::HOME_DIR)
+            console.warning_with "WARN: Ignorning home directory config! System config is enforced."
+          else
+            console.info_with "INFO: System config is enforced."
+          end
+        end
+      end
+
       # Find and load config file,
       # - start by looking for an "enforced" system config file
       # - next if a config file was specified via command,
@@ -239,17 +253,7 @@ module Enkaidu
                   Config.find_config_file(Env::HOME_DIR)
           parse_config_file(file)
         end
-        if Enkaidu.enforce_system_config?
-          if @options[:config_file]?
-            console.warning_with "WARN: Ignorning specified config! System config is enforced."
-          elsif Config.find_config_file(Env::CURRENT_DIR)
-            console.warning_with "WARN: Ignorning current directory config! System config is enforced."
-          elsif Config.find_config_file(Env::HOME_DIR)
-            console.warning_with "WARN: Ignorning home directory config! System config is enforced."
-          else
-            console.info_with "INFO: System config is enforced."
-          end
-        end
+        report_enforce_system_config_override
       rescue IO::Error
         # If we fail to find default config file, it's OK.
         if @options[:config_file]?

--- a/src/enkaidu/cli/options.cr
+++ b/src/enkaidu/cli/options.cr
@@ -107,15 +107,15 @@ module Enkaidu
               If using a provider, different types depend on different environment
               variables.
 
-              ollama          OLLAMA_ENDPOINT (defaults to http://localhost:11434)
-              openai          OPENAI_MODEL, OPENAI_API_KEY,
+              ollama            OLLAMA_ENDPOINT (defaults to http://localhost:11434)
+              openai            OPENAI_MODEL, OPENAI_API_KEY,
                                     OPENAI_ENDPOINT (defaults to https://api.openai.com)
-              azure_openai    AZURE_OPENAI_MODEL, AZURE_OPENAI_ENDPOINT,
+              azure_openai      AZURE_OPENAI_MODEL, AZURE_OPENAI_ENDPOINT,
                                     AZURE_OPENAI_API_KEY, AZURE_OPENAI_API_VER
 
               (Early access)
-              gemini_openai   GEMINI_API_KEY (required), GEMINI_OPENAI_ENDPOINT,
-                                    GEMINI_OPENAI_CHAT_PATH
+              google_ai_studio   GOOGLE_AI_API_KEY (required), GOOGLE_AI_ENDPOINT,
+                                    GOOGLE_AI_OPENAI_CHAT_PATH
       PROVIDER
       end
 

--- a/src/enkaidu/cli/query_reader.cr
+++ b/src/enkaidu/cli/query_reader.cr
@@ -109,10 +109,6 @@ module Enkaidu::CLI
       expression.strip
     end
 
-    # def indentation_level(expression_before_cursor : String) : Int32?
-    #   # Compute the indentation from the expression
-    # end
-
     def save_in_history?(expression : String) : Bool
       true
     end
@@ -120,9 +116,5 @@ module Enkaidu::CLI
     def history_file
       @input_history_file ||= ENV.fetch("ENKAIDU_HISTORY_FILE", ".enkaidu_history")
     end
-
-    # def auto_complete(name_filter : String, expression : String) : {String, Array(String)}
-    #   # Return the auto-completion result from expression
-    # end
   end
 end

--- a/src/enkaidu/cli/system_enforcement.cr
+++ b/src/enkaidu/cli/system_enforcement.cr
@@ -1,0 +1,36 @@
+module Enkaidu
+  #
+  # Enforced system config
+  # -----------------------
+  #
+  # If a system-level config file is found, then Enkaidu ONLY uses that config and does not
+  # allow any local config file to override the configuration.
+  #
+  # - Command line options are supported (except those that modify config file)
+  # - Profile folder's macro, prompts, etc are supported (except the config file)
+  #
+  # This allows someone to offer a shared system with a single admin-managed Enkaidu configuration
+  # that prevents the use of local / custom configs that could undo security controls
+  #
+  @@enforce_system_config = false
+
+  # Return true if a system config file was detected and loaded
+  def self.enforce_system_config?
+    @@enforce_system_config
+  end
+
+  # The system config file location is platform dependent
+  {% if flag?(:windows) %}
+    ENFORCED_SYS_CONFIG_FILE = Path.new(["C:", "Windows", "System32", "drivers", "etc", "enkaidu.yml"]).to_s
+  {% else %}
+    ENFORCED_SYS_CONFIG_FILE = "/etc/enkaidu.yml"
+  {% end %}
+
+  # Look for the system config file and if present: (a) enable enforcement, and (b)return its path
+  protected def self.enforced_system_config_file
+    if File.exists?(ENFORCED_SYS_CONFIG_FILE)
+      @@enforce_system_config = true
+      ENFORCED_SYS_CONFIG_FILE
+    end
+  end
+end

--- a/src/enkaidu/config.cr
+++ b/src/enkaidu/config.cr
@@ -93,9 +93,9 @@ module Enkaidu
       # Excluding reasoning in "past turn" chat responses to LLM disabled by default
       getter? exclude_past_reasoning = false
 
-      # Allowed by default, set to false to disallow
-      getter? allow_tool_discovery = true
-      getter? allow_sub_agents = true
+      # Disallowed by default, set to `true` to disallow
+      getter? allow_tool_discovery = false
+      getter? allow_sub_agents = false
 
       getter provider_type : String?
       getter model : String?

--- a/src/enkaidu/config.cr
+++ b/src/enkaidu/config.cr
@@ -81,9 +81,18 @@ module Enkaidu
 
     # Session configuration settings for Enkaidu.
     class Session < ConfigSerializable
-      getter? streaming = false
+      # Streaming chat enabled by default
+      getter? streaming = true
+
+      # Quiet mode disabled by default
       getter? quiet = false
+
+      # Readonly mode disallows built-in tools when enabled; disabled by default
+      getter? readonly = false
+
+      # Excluding reasoning in "past turn" chat responses to LLM disabled by default
       getter? exclude_past_reasoning = false
+
       getter provider_type : String?
       getter model : String?
       getter input_history_file : String?

--- a/src/enkaidu/config.cr
+++ b/src/enkaidu/config.cr
@@ -93,6 +93,10 @@ module Enkaidu
       # Excluding reasoning in "past turn" chat responses to LLM disabled by default
       getter? exclude_past_reasoning = false
 
+      # Allowed by default, set to false to disallow
+      getter? allow_tool_discovery = true
+      getter? allow_sub_agents = true
+
       getter provider_type : String?
       getter model : String?
       getter input_history_file : String?

--- a/src/enkaidu/console/renderer.cr
+++ b/src/enkaidu/console/renderer.cr
@@ -11,7 +11,7 @@ module Enkaidu::Console
   class Renderer < SessionRenderer
     include StyleApplicator
 
-    property? streaming = false
+    property? streaming = true
     property? quiet = false
 
     # Internal input for prompt args

--- a/src/enkaidu/env/profile.cr
+++ b/src/enkaidu/env/profile.cr
@@ -79,15 +79,20 @@ module Enkaidu::Env
     private def load_profile_config(quiet) : ProfileConfig?
       if file = (dir = profile_path) &&
                 Config.find_config_file(dir, base_name: CONFIG_FILE_NAME)
-        begin
-          parse_config_file(file, quiet)
-        rescue IO::Error
-          error_and_exit_with "FATAL: Failed to open profile config file: #{file.relative_to?(CURRENT_DIR)}"
-        rescue ex : TooManyDefaultConfigFiles | UnknownConfigFileFormat
-          error_and_exit_with "FATAL: #{ex}"
-        rescue ex : ConfigParseError
-          # Config parsing errors are always bad
-          error_and_exit_with "FATAL: Error parsing profile config file: #{file.relative_to?(CURRENT_DIR)}\n#{ex}"
+        if Enkaidu.enforce_system_config?
+          renderer.warning_with "WARN: Ignorning profile config! System config is enforced."
+          nil
+        else
+          begin
+            parse_config_file(file, quiet)
+          rescue IO::Error
+            error_and_exit_with "FATAL: Failed to open profile config file: #{file.relative_to?(CURRENT_DIR)}"
+          rescue ex : TooManyDefaultConfigFiles | UnknownConfigFileFormat
+            error_and_exit_with "FATAL: #{ex}"
+          rescue ex : ConfigParseError
+            # Config parsing errors are always bad
+            error_and_exit_with "FATAL: Error parsing profile config file: #{file.relative_to?(CURRENT_DIR)}\n#{ex}"
+          end
         end
       else
         nil

--- a/src/enkaidu/runtime.cr
+++ b/src/enkaidu/runtime.cr
@@ -25,20 +25,14 @@ module Enkaidu
       @commander = Slash::Commander.new(session_manager)
 
       # Inject system tools based on session configuration
-      # Default is true, and session config may be absent, so
-      # start with assumption and import from config if any
-      allow_tool_discovery = true
-      allow_sub_agents = true
       if session_config = options.config.session
-        allow_tool_discovery = session_config.allow_tool_discovery?
-        allow_sub_agents = session_config.allow_sub_agents?
-      end
-      if allow_tool_discovery
-        session_manager.inject_function ListInstallableTools.new(self)
-        session_manager.inject_function InstallToolsFunction.new(self)
-      end
-      if allow_sub_agents
-        session_manager.inject_function SubAgentPromptFunction.new(self)
+        if session_config.allow_tool_discovery?
+          session_manager.inject_function ListInstallableTools.new(self)
+          session_manager.inject_function InstallToolsFunction.new(self)
+        end
+        if session_config.allow_sub_agents?
+          session_manager.inject_function SubAgentPromptFunction.new(self)
+        end
       end
 
       # HACK ALERT

--- a/src/enkaidu/runtime.cr
+++ b/src/enkaidu/runtime.cr
@@ -24,12 +24,22 @@ module Enkaidu
       @session_manager = SessionManager.new(Session.new(renderer, opts: options))
       @commander = Slash::Commander.new(session_manager)
 
-      # Always enable tools for
-      # - spawning agent
-      # - tools catalog
-      session_manager.inject_function ListInstallableTools.new(self)
-      session_manager.inject_function InstallToolsFunction.new(self)
-      session_manager.inject_function SubAgentPromptFunction.new(self)
+      # Inject system tools based on session configuration
+      # Default is true, and session config may be absent, so
+      # start with assumption and import from config if any
+      allow_tool_discovery = true
+      allow_sub_agents = true
+      if session_config = options.config.session
+        allow_tool_discovery = session_config.allow_tool_discovery?
+        allow_sub_agents = session_config.allow_sub_agents?
+      end
+      if allow_tool_discovery
+        session_manager.inject_function ListInstallableTools.new(self)
+        session_manager.inject_function InstallToolsFunction.new(self)
+      end
+      if allow_sub_agents
+        session_manager.inject_function SubAgentPromptFunction.new(self)
+      end
 
       # HACK ALERT
       # I don't like this; but for now I don't have a better way.

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -78,13 +78,11 @@ module Enkaidu
       end
 
       setup_envs_from_config
-      @connection = case provider_type || opts.provider_type
-                    when "openai"       then LLM::OpenAI::Connection.new
-                    when "azure_openai" then LLM::AzureOpenAI::Connection.new
-                    when "ollama"       then LLM::Ollama::Connection.new
-                    else
-                      opts.error_and_exit_with "FATAL: Unknown provider type: #{opts.provider_type}", opts.help
-                    end
+      llm_conn = if provider_name = provider_type || opts.provider_type
+                   LLM.connection_by(provider: provider_name)
+                 end
+      @connection = llm_conn ||
+                    opts.error_and_exit_with "FATAL: Unknown provider type: #{opts.provider_type}", opts.help
 
       @chat = setup_chat(override_model_name: model_name)
       @renderer.streaming = chat.streaming?

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -152,10 +152,20 @@ module Enkaidu
     end
 
     # Return based on session override, or model settings
-    private def exclude_past_reasoning?
+    def exclude_past_reasoning? : Bool
       opts.config.session.try(&.exclude_past_reasoning?) ||
         @model_config.try(&.settings.try(&.exclude_past_reasoning?)) ||
         false
+    end
+
+    # Return based on session override
+    def allow_tool_discovery? : Bool
+      opts.config.session.try(&.allow_tool_discovery?) || false
+    end
+
+    # Return based on session override
+    def allow_sub_agents? : Bool
+      opts.config.session.try(&.allow_sub_agents?) || false
     end
 
     # Load the selected LLM's environment variable values into
@@ -167,31 +177,32 @@ module Enkaidu
       end
     end
 
+    private SYSPROMPT_TOOL_DISCOVERY = <<-EMPOWERED
+    <empowered>
+    * If you need tools to solve a task, REMEMBER to look up and install them using the following tools _since not all tools are pre-installed_:
+      - `list_installable_tools` to find available tools.
+      - `install_tools` to activate tools
+    </empowered>
+    EMPOWERED
+
     private def system_prompt(override_system_prompt : String?)
       <<-WRAPPED
       You are Enkaidu, a capable assistant with tool calling and the ability to handle complex requests with planning and consideration.
-
       <attitude>
       * Keep a natural, conversational tone and use minimal formatting - no bold, no headers, no lists - unless the user explicitly asks or the content is multi-faceted.
       * Never use emojis unless requested, and even then only judiciously.
       </attitude>
-
       <planner>
       * Plan what it will take to answer a question or complete a task.
       * When a user poses a multi-part question, limit yourself to one question per response
       * Resolve each question before asking follow-ups.
       * Ask for feedback on the plan.
       </planner>
-
-      <empowered>
-      * REMEMBER to install tools you need; _not all tools are pre-installed_.
-        - Use the tool `list_installable_tools` to find installable tools.
-        - Use the tool `install_tools` for the tools you need
-      </empowered>
-
-      #{if prompt = override_system_prompt
-          "\n## Additional guidance\n#{prompt}\n"
-        end}
+      #{if allow_tool_discovery?
+          SYSPROMPT_TOOL_DISCOVERY
+        end}#{if prompt = override_system_prompt
+                "\n<additional-guidance>\n#{prompt.strip}\n</additional-guidance>"
+              end}
       WRAPPED
     end
 

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -198,12 +198,14 @@ module Enkaidu
     end
 
     private macro m_process_and_record_ask_event(event, prev_event)
-      type = {{event}}["type"]
-      unless type == "done"
-        recorder.if_recording? do |io|
-          io.puts "," if ix.positive?
-          io.puts {{event}}.to_json
-        end
+      recorder.if_recording? do |io|
+        io.puts "," if ix.positive?
+        io.puts {{event}}.to_json
+      end
+      case type = {{event}}["type"]
+      when "done"
+        detect_text_ending(type, prev_event)
+      else
         ix += 1
         process_event({{event}}, {{prev_event}}) do |tool_call|
           tools << tool_call

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -196,7 +196,7 @@ module Enkaidu
       * Plan what it will take to answer a question or complete a task.
       * When a user poses a multi-part question, limit yourself to one question per response
       * Resolve each question before asking follow-ups.
-      * Ask for feedback on the plan.
+      * Proceed with the plan unless the plan is complicated and warrants user feedback.
       </planner>
       #{if allow_tool_discovery?
           SYSPROMPT_TOOL_DISCOVERY

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -21,6 +21,8 @@ module Enkaidu
 
   class InvalidMacroCall < Exception; end
 
+  class UnexpectedError < Exception; end
+
   # The Session class manages connection setup, logging, and the processing of
   # different types of events for user queries via the command line app
   class Session
@@ -58,6 +60,7 @@ module Enkaidu
 
     delegate streaming?, usage, to: @chat
     delegate debug?, to: @opts
+    delegate readonly?, to: @opts
 
     def initialize(@renderer, @opts,
                    unique_model_name : String? = nil)
@@ -141,6 +144,7 @@ module Enkaidu
         end
         with_debug if opts.debug?
         with_streaming if opts.stream?
+        with_readonly if readonly?
         with_system_message system_prompt(override_system_prompt)
 
         if effort = @model_config.try(&.settings.try(&.think))

--- a/src/enkaidu/session/auto_load.cr
+++ b/src/enkaidu/session/auto_load.cr
@@ -46,7 +46,7 @@ module Enkaidu
         if autoload = config.auto_load
           if name = autoload.system_prompt_name
             if sys_prompt = render_system_prompt(name)
-              @chat.with_system_message(sys_prompt)
+              @chat.with_system_message(system_prompt(sys_prompt))
             else
               renderer.warning_with("WARN: Unable to use system prompt named '#{name}")
             end

--- a/src/enkaidu/session/toolsets.cr
+++ b/src/enkaidu/session/toolsets.cr
@@ -11,8 +11,6 @@ module Enkaidu
             io << "---|---|----\n"
             chat.each_tool(origin: origin) do |tool|
               io << '`' << tool.name << "` | " << tool.side_effects.value_string << " | " << tool.summary << '\n'
-              # io << "#### `" << tool.name << "`\n"
-              # io << tool.description << "\n\n"
             end
           end
           io << '\n'
@@ -122,9 +120,11 @@ module Enkaidu
             loaded = @loaded_toolsets.has_key?(toolset.name)
             io << "### " << toolset.name
             io << (loaded ? " _(Loaded)_\n" : '\n')
-            toolset.each_tool_info(readonly: readonly?) do |name, description|
-              io << "- `" << name << "` : "
-              io << description << "\n\n"
+
+            io << "Tool | Side-effects | Summary\n"
+            io << "---|---|----\n"
+            toolset.each_tool_class(readonly: readonly?) do |name, tool_class|
+              io << '`' << name << "` | " << tool_class.side_effects.value_string << " | " << tool_class.summary << '\n'
               count += 1
             end
             io.puts "* _No read-only tools available!_" if count.zero?

--- a/src/enkaidu/session/toolsets.cr
+++ b/src/enkaidu/session/toolsets.cr
@@ -3,18 +3,21 @@ require "../../tools"
 module Enkaidu
   class Session
     module Toolsets
-      def list_all_tools
+      def list_active_tools
         text = String.build do |io|
           chat.each_tool_origin do |origin|
             io << "### " << origin << '\n'
+            io << "Tool | Side-effects | Summary\n"
+            io << "---|---|----\n"
             chat.each_tool(origin: origin) do |tool|
-              io << "`" << tool.name << "` : "
-              io << tool.description << "\n\n"
+              io << '`' << tool.name << "` | " << tool.side_effects.value_string << " | " << tool.summary << '\n'
+              # io << "#### `" << tool.name << "`\n"
+              # io << tool.description << "\n\n"
             end
           end
           io << '\n'
         end
-        renderer.respond_with("List of available tools.", text, markdown: true)
+        renderer.respond_with("List of enabled / active tools.", text, markdown: true)
       end
 
       def unload_all_toolsets
@@ -55,6 +58,7 @@ module Enkaidu
       end
 
       private def load_tool_by_class(tool_class) : LLM::Function
+        raise UnexpectedError.new("Tool (#{tool_class.name}) is not read-only; report this please.") if readonly? && !tool_class.side_effects.readonly?
         fun_name = tool_class.function_name
         settings = opts.config.tool_settings_by_name(fun_name)
         tool = tool_class.new(renderer, settings)
@@ -77,12 +81,13 @@ module Enkaidu
             message = String.build do |str|
               str << "Loaded built-in tools from toolset: "
               ix = 0
-              toolset.retrieve(selection: selection) do |built_in_function_class|
+              toolset.retrieve(readonly: readonly?, selection: selection) do |built_in_function_class|
                 tool = load_tool_by_class(built_in_function_class)
                 str << ", " if ix.positive?
                 str << tool.name
                 ix += 1
               end
+              str << "None" if ix.zero?
             end
             if auto
               renderer.info_with message
@@ -99,7 +104,7 @@ module Enkaidu
       def load_tools_across_toolsets(tool_names : Enumerable(String))
         loaded = [] of NamedTuple(toolset: String, tool: String)
         Tools.each_toolset do |toolset|
-          toolset.each_tool_class do |name, tool_class|
+          toolset.each_tool_class(readonly: readonly?) do |name, tool_class|
             next unless tool_names.includes?(name)
             unless tool_loaded?(name)
               load_tool_by_class(tool_class)
@@ -110,16 +115,19 @@ module Enkaidu
         loaded # return list of tools loaded.
       end
 
-      def list_all_toolsets
+      def list_available_toolsets
         text = String.build do |io|
           Tools.each_toolset do |toolset|
+            count = 0
             loaded = @loaded_toolsets.has_key?(toolset.name)
-            io << "# " << toolset.name
+            io << "### " << toolset.name
             io << (loaded ? " _(Loaded)_\n" : '\n')
-            toolset.each_tool_info do |name, description|
-              io << "* `" << name << "` : "
+            toolset.each_tool_info(readonly: readonly?) do |name, description|
+              io << "- `" << name << "` : "
               io << description << "\n\n"
+              count += 1
             end
+            io.puts "* _No read-only tools available!_" if count.zero?
           end
           io << '\n'
         end
@@ -128,18 +136,23 @@ module Enkaidu
 
       def list_tool_details(tool_name)
         if tool = chat.find_tool?(tool_name)
-          text = String.build do |io|
-            desc = if tool.description == tool_name
-                     "_No description provided. Using tool name instead._"
-                   else
-                     tool.description
-                   end
-            io << desc << '\n'
-            io << "### Input Schema (Parameters)\n```json\n"
-            io << JSON.parse(tool.input_json_schema).to_pretty_json
-            io << "\n```\n"
+          if !readonly? || tool.side_effects.readonly?
+            text = String.build do |io|
+              desc = if tool.description == tool_name
+                       "_No description provided. Using tool name instead._"
+                     else
+                       tool.description
+                     end
+              io << desc << '\n'
+              io << "### Input Schema (Parameters)\n```json\n"
+              io << JSON.parse(tool.input_json_schema).to_pretty_json
+              io << "\n```\n"
+            end
+            renderer.respond_with("Tool details: #{tool_name} (#{tool.origin})", text, markdown: true)
+          else
+            # TBH, if #readonly? this should never happen.
+            renderer.warning_with("Only read-only tools allowed. Tool not available: #{tool_name}")
           end
-          renderer.respond_with("Tool details: #{tool_name} (#{tool.origin})", text, markdown: true)
         else
           renderer.info_with("INFO: No such tool available: #{tool_name}")
         end
@@ -150,7 +163,7 @@ module Enkaidu
       def tools_catalog_builder(json : JSON::Builder) : Nil
         json.array do
           Tools.each_toolset do |toolset|
-            toolset.each_tool_info do |name, description|
+            toolset.each_tool_info(readonly: readonly?) do |name, description|
               json.object do
                 json.field "tool", name
                 json.field "toolset", toolset.name

--- a/src/enkaidu/session/toolsets.cr
+++ b/src/enkaidu/session/toolsets.cr
@@ -144,6 +144,7 @@ module Enkaidu
                        tool.description
                      end
               io << desc << '\n'
+              io << "### Side-effects\n" << tool.side_effects.value_string << "\n\n"
               io << "### Input Schema (Parameters)\n```json\n"
               io << JSON.parse(tool.input_json_schema).to_pretty_json
               io << "\n```\n"

--- a/src/enkaidu/slash/tool.cr
+++ b/src/enkaidu/slash/tool.cr
@@ -8,7 +8,7 @@ module Enkaidu::Slash
     HELP       = <<-HELP1
     #{HELP_BRIEF}
     - `ls`
-      - List all available tools
+      - List all enabled / active tools
     - `info <TOOLNAME>`
       - Provide details about one tool
     HELP1
@@ -28,7 +28,7 @@ module Enkaidu::Slash
     def handle(session_manager : SessionManager, cmd : CommandParser)
       session = session_manager.current.session
       if cmd.expect?(NAME, "ls")
-        session.list_all_tools
+        session.list_active_tools
       elsif cmd.expect?(NAME, "info", String)
         session.list_tool_details((cmd.arg_at? 2).as(String))
       else

--- a/src/enkaidu/slash/toolset.cr
+++ b/src/enkaidu/slash/toolset.cr
@@ -12,7 +12,7 @@ module Enkaidu::Slash
       - List all built-in and available toolsets that can be enabled / activated
     - `load <TOOLSET_NAME>`
       - Load all the tools from the named toolset
-    - `load <TOOLSET_NAME> select=LIST_TOOL_NAMES
+    - `load <TOOLSET_NAME> select=LIST_TOOL_NAMES`
       - Load the selected tools from the named toolset
       - E.g. `/toolset load FileManagement select=[list_files rename_file]`
     - `unload <TOOLSET_NAME>`

--- a/src/enkaidu/slash/toolset.cr
+++ b/src/enkaidu/slash/toolset.cr
@@ -9,7 +9,7 @@ module Enkaidu::Slash
     HELP = <<-HELP1
     #{HELP_BRIEF}
     - `ls`
-      - List all built-in toolsets that can be activated
+      - List all built-in and available toolsets that can be enabled / activated
     - `load <TOOLSET_NAME>`
       - Load all the tools from the named toolset
     - `load <TOOLSET_NAME> select=LIST_TOOL_NAMES
@@ -34,7 +34,7 @@ module Enkaidu::Slash
     def handle(session_manager : SessionManager, cmd : CommandParser)
       session = session_manager.current.session
       if cmd.expect?(NAME, "ls")
-        session.list_all_toolsets
+        session.list_available_toolsets
       elsif cmd.expect?(NAME, "load", String, select: Array(String)?)
         if name = cmd.arg_at?(2)
           selection = cmd.arg_named?("select").try(&.as(Array(String)))

--- a/src/enkaidu/tools/install_tools_function.cr
+++ b/src/enkaidu/tools/install_tools_function.cr
@@ -4,6 +4,7 @@ require "./session_built_in_function"
 module Enkaidu
   class InstallToolsFunction < SessionBuiltInFunction
     name "install_tools"
+    side_effects SideEffects::None
 
     description <<-DESC
     Install one or more tools from the list of installable tools. Tool names are unique across toolsets.

--- a/src/enkaidu/tools/list_installable_tools_function.cr
+++ b/src/enkaidu/tools/list_installable_tools_function.cr
@@ -4,6 +4,7 @@ require "./session_built_in_function"
 module Enkaidu
   class ListInstallableTools < SessionBuiltInFunction
     name "list_installable_tools"
+    side_effects SideEffects::None
 
     description <<-DESC
     Obtain a list of available tools that you can install. Use the list to determine the tools that will help with

--- a/src/enkaidu/tools/mcp_function.cr
+++ b/src/enkaidu/tools/mcp_function.cr
@@ -12,6 +12,9 @@ module Enkaidu
     getter title : String? = nil
     getter description : String
 
+    # Don't know what the MCP server does, it could be local, it could be remote.
+    getter side_effects : LLM::Function::SideEffects = SideEffects::All
+
     # Accessible to the function's Runner
     protected getter mcpc : MCPC::HttpConnection
     protected getter cli : Session

--- a/src/enkaidu/tools/sub_agent_function.cr
+++ b/src/enkaidu/tools/sub_agent_function.cr
@@ -6,6 +6,9 @@ module Enkaidu
   class SubAgentPromptFunction < SessionBuiltInFunction
     name "spawn_agent"
 
+    # By itself, has no sideffects
+    side_effects SideEffects::None
+
     description <<-DESC
     Run a prompt in a completely fresh, isolated context window and receive the result as `[query, response]`.
 

--- a/src/llm.cr
+++ b/src/llm.cr
@@ -1,7 +1,7 @@
 require "./llm/local_function"
 require "./llm/connection"
 require "./llm/azure_openai"
-require "./llm/gemini_openai"
+require "./llm/google_ai_studio"
 require "./llm/ollama"
 
 module LLM
@@ -20,13 +20,13 @@ module LLM
   end
 
   # Returns an instance of a provider-specific `LLM::Connection`, for known `provider` (one of
-  # `openai`, `ollama`, `azure_openai`, or `gemini_openai`) or `nil` if unknown.
+  # `openai`, `ollama`, `azure_openai`, or `google_ai_studio`) or `nil` if unknown.
   def self.connection_by(provider : String) : Connection?
     case provider
-    when "openai"        then OpenAI::Connection.new
-    when "ollama"        then Ollama::Connection.new
-    when "azure_openai"  then AzureOpenAI::Connection.new
-    when "gemini_openai" then GeminiOpenAI::Connection.new
+    when "openai"           then OpenAI::Connection.new
+    when "ollama"           then Ollama::Connection.new
+    when "azure_openai"     then AzureOpenAI::Connection.new
+    when "google_ai_studio" then GoogleAIStudio::Connection.new
     end
   end
 end

--- a/src/llm.cr
+++ b/src/llm.cr
@@ -1,6 +1,7 @@
 require "./llm/local_function"
 require "./llm/connection"
 require "./llm/azure_openai"
+require "./llm/gemini_openai"
 require "./llm/ollama"
 
 module LLM
@@ -16,5 +17,16 @@ module LLM
             ~~~~~~~~~~~~~~~~~~~~
             ERROR
     STDERR.puts msg.colorize(:magenta)
+  end
+
+  # Returns an instance of a provider-specific `LLM::Connection`, for known `provider` (one of
+  # `openai`, `ollama`, `azure_openai`, or `gemini_openai`) or `nil` if unknown.
+  def self.connection_by(provider : String) : Connection?
+    case provider
+    when "openai"        then OpenAI::Connection.new
+    when "ollama"        then Ollama::Connection.new
+    when "azure_openai"  then AzureOpenAI::Connection.new
+    when "gemini_openai" then GeminiOpenAI::Connection.new
+    end
   end
 end

--- a/src/llm/chat.cr
+++ b/src/llm/chat.cr
@@ -29,6 +29,7 @@ module LLM
     getter system_message : String | Nil = nil
     getter? debug = false
     getter? streaming = false
+    getter? readonly = false
     getter reasoning = Reasoning::Default
 
     def initialize
@@ -48,6 +49,22 @@ module LLM
       @streaming = true
     end
 
+    # Make chat session read-only. This will remove all tools that are not readonly.
+    def with_readonly
+      @readonly = true
+
+      # Find and remove any tools that are not read-only
+      not_readonly = [] of Function
+      each_tool do |tool|
+        unless tool.side_effects.readonly?
+          not_readonly << tool
+        end
+      end
+      not_readonly.each do |tool|
+        without_tool(tool)
+      end
+    end
+
     def with_model(model : String)
       @model = model
     end
@@ -56,7 +73,9 @@ module LLM
       @system_message = content
     end
 
-    def with_tool(function : Function)
+    # Return nil if unable to use / enable the function
+    def with_tool(function : Function) : Function?
+      return if readonly? && !function.side_effects.readonly?
       return if @tools_by_name[function.name]?
       @tools_by_name[function.name] = function
       by_origin = @tools_by_origin[function.origin]? ||

--- a/src/llm/function.cr
+++ b/src/llm/function.cr
@@ -70,6 +70,7 @@ module LLM
 
     # Internal use only
     @summary : String?
+    @@summary : String?
 
     # The summary of the description; splits by '.' and then `\n' to return first entry.
     def summary : String

--- a/src/llm/function.cr
+++ b/src/llm/function.cr
@@ -3,11 +3,58 @@ require "json"
 module LLM
   # Defines custom function tool
   abstract class Function
+    @[Flags]
+    enum SideEffects
+      FileRead
+      FileWrite
+      FileMove
+      FileDelete
+      DirRead
+      DirWrite
+      DirMove
+      DirDel
+      NetRead
+      NetWrite
+      CommandExec
+
+      # Returns true if side-effects are read-only.
+      def readonly?
+        (self & ~(FileRead | DirRead | NetRead)).to_u32.zero?
+      end
+
+      # Return true if accesses network
+      def network?
+        net_read? || net_write?
+      end
+
+      # Return a comma-separated value string of flags, or `None`
+      def value_string
+        String.build do |str_io|
+          ix = 0
+          self.each do |val|
+            str_io << ", " if ix.positive?
+            str_io << val
+            ix += 1
+          end
+          str_io << "None" if ix.zero?
+        end
+      end
+    end
+
     # Define a settings Hash with fixed value types for use with functions
     class Settings < Hash(String, String | Int64 | Bool | Array(String) | Array(Int64)); end
 
     abstract def name : String
     abstract def description : String
+    abstract def summary : String
+
+    def self.side_effects : SideEffects
+      SideEffects::All
+    end
+
+    def side_effects
+      self.class.side_effects
+    end
 
     # A short title about the origin of the function
     getter origin : String = "Unknown"
@@ -15,6 +62,24 @@ module LLM
     getter settings : Settings?
 
     def initialize(@origin, @settings = nil); end
+
+    # Returns true if this tools side-effects are read-only.
+    def readonly?
+      side_effects.readonly?
+    end
+
+    # Internal use only
+    @summary : String?
+
+    # The summary of the description; splits by '.' and then `\n' to return first entry.
+    def summary : String
+      @summary ||= description.split('.', limit: 2).first.split('\n', limit: 2).first
+    end
+
+    # The static summary of the description; splits by '.' and then `\n' to return first entry.
+    def self.summary : String
+      @@summary ||= description.split('.', limit: 2).first.split('\n', limit: 2).first
+    end
 
     # This defines the runner that is instantiated to
     # execute the function.

--- a/src/llm/gemini_openai/connection.cr
+++ b/src/llm/gemini_openai/connection.cr
@@ -1,0 +1,29 @@
+require "http/client"
+require "uri"
+
+require "../openai"
+
+module LLM::GeminiOpenAI
+  # `Connection` is a class that extends from `OpenAI::Connection` to provide
+  # specialized connection handling for Azure OpenAI services.
+  class Connection < OpenAI::Connection
+    def api_key
+      ENV["GEMINI_API_KEY"]
+    end
+
+    protected def url : String
+      ENV["GEMINI_OPENAI_ENDPOINT"]? || "https://generativelanguage.googleapis.com"
+    end
+
+    protected def path : String
+      ENV["GEMINI_OPENAI_CHAT_PATH"]? || "/v1beta/openai/chat/completions"
+    end
+
+    protected def headers : HTTP::Headers
+      HTTP::Headers{
+        "Content-Type"  => "application/json",
+        "Authorization" => "Bearer #{api_key}",
+      }
+    end
+  end
+end

--- a/src/llm/gemini_openai/gemini_openai.cr
+++ b/src/llm/gemini_openai/gemini_openai.cr
@@ -1,0 +1,6 @@
+require "./connection"
+
+# The `GeminiOpenAI` module lets you connect and chat with
+# Google Gemini's LLMs via their OpenAI compatibility endpoint
+module LLM::GeminiOpenAI
+end

--- a/src/llm/gemini_openai/gemini_openai.cr
+++ b/src/llm/gemini_openai/gemini_openai.cr
@@ -1,6 +1,0 @@
-require "./connection"
-
-# The `GeminiOpenAI` module lets you connect and chat with
-# Google Gemini's LLMs via their OpenAI compatibility endpoint
-module LLM::GeminiOpenAI
-end

--- a/src/llm/google_ai_studio/connection.cr
+++ b/src/llm/google_ai_studio/connection.cr
@@ -3,20 +3,20 @@ require "uri"
 
 require "../openai"
 
-module LLM::GeminiOpenAI
+module LLM::GoogleAIStudio
   # `Connection` is a class that extends from `OpenAI::Connection` to provide
   # specialized connection handling for Azure OpenAI services.
   class Connection < OpenAI::Connection
     def api_key
-      ENV["GEMINI_API_KEY"]
+      ENV["GOOGLE_AI_API_KEY"]
     end
 
     protected def url : String
-      ENV["GEMINI_OPENAI_ENDPOINT"]? || "https://generativelanguage.googleapis.com"
+      ENV["GOOGLE_AI_ENDPOINT"]? || "https://generativelanguage.googleapis.com"
     end
 
     protected def path : String
-      ENV["GEMINI_OPENAI_CHAT_PATH"]? || "/v1beta/openai/chat/completions"
+      ENV["GOOGLE_AI_OPENAI_CHAT_PATH"]? || "/v1beta/openai/chat/completions"
     end
 
     protected def headers : HTTP::Headers

--- a/src/llm/google_ai_studio/google_ai_studio.cr
+++ b/src/llm/google_ai_studio/google_ai_studio.cr
@@ -1,0 +1,6 @@
+require "./connection"
+
+# The `GoogleAIStudio` module lets you connect and chat with
+# Google AI Studio's Gemini LLMs via their OpenAI compatibility endpoint
+module LLM::GoogleAIStudio
+end

--- a/src/llm/local_function.cr
+++ b/src/llm/local_function.cr
@@ -81,6 +81,11 @@ module LLM
     end
 
     # Set the name for the function.
+    macro side_effects(effects)
+      class_getter side_effects : SideEffects = {{ effects }}
+    end
+
+    # Set the name for the function.
     macro name(str)
       # The name of the function
       def self.function_name : String

--- a/src/llm/openai/chat.cr
+++ b/src/llm/openai/chat.cr
@@ -270,7 +270,8 @@ module LLM::OpenAI
       FunctionCall.new(
         name: tool_call.dig("function", "name").as_s,
         id: tool_call["id"].as_s,
-        args_json: tool_call.dig("function", "arguments").as_s
+        args_json: tool_call.dig("function", "arguments").as_s,
+        extra_content: tool_call.dig?("extra_content")
       )
     end
 

--- a/src/llm/openai/chat.cr
+++ b/src/llm/openai/chat.cr
@@ -131,7 +131,10 @@ module LLM::OpenAI
           append_message error_calling_tool(
             call.dig("id").as_s,
             name,
-            error: "The tool #{name} is not installed. Consider installing it first.",
+            error: case name
+            when .blank? then "The tool name cannot be empty string."
+            else              "The tool #{name} is not installed. Consider installing it first."
+            end
           )
         end
         calls += 1

--- a/src/llm/openai/converters.cr
+++ b/src/llm/openai/converters.cr
@@ -16,6 +16,9 @@ module LLM::OpenAI
             json.field "name", f.name
           end
         end
+        if extra = f.extra_content
+          json.field "extra_content", extra
+        end
       end
     end
 

--- a/src/llm/openai/function_call.cr
+++ b/src/llm/openai/function_call.cr
@@ -7,8 +7,9 @@ module LLM::OpenAI
     getter id : String
     getter args_json : String
     getter? ready
+    getter extra_content : JSON::Any?
 
-    def initialize(@name, @id, @args_json = "", @ready = false); end
+    def initialize(@name, @id, @args_json = "", @ready = false, @extra_content = nil); end
 
     def append_args_json(args_part : String?, complete = false)
       return if ready?

--- a/src/tools/toolset.cr
+++ b/src/tools/toolset.cr
@@ -23,15 +23,19 @@ module Tools
       @tool_names = nil
     end
 
-    def each_tool_class(&)
-      @tools.each do |name, tool_class|
-        yield name, tool_class
+    def each_tool_class(readonly = false, &)
+      @tools.each do |name, fun_class|
+        if !readonly || fun_class.side_effects.readonly?
+          yield name, fun_class
+        end
       end
     end
 
-    def each_tool_info(&)
+    def each_tool_info(readonly = false, &)
       @tools.each do |name, fun_class|
-        yield name, fun_class.description
+        if !readonly || fun_class.side_effects.readonly?
+          yield name, fun_class.description
+        end
       end
     end
 
@@ -41,9 +45,10 @@ module Tools
 
     # Call this method to retrieve built-in tool/function classes
     # from this `ToolSet`, optionally using a `selection` of tool names to filter the tools
-    def retrieve(selection : Enumerable(String)? = nil,
+    def retrieve(readonly = false, selection : Enumerable(String)? = nil,
                  & : BuiltInFunction.class ->)
       @tools.each_value do |fun_class|
+        next if readonly && !fun_class.side_effects.readonly?
         next if selection && !selection.includes?(fun_class.function_name)
 
         yield fun_class

--- a/src/tools/toolsets/date_and_time/get_current_datetime_tool.cr
+++ b/src/tools/toolsets/date_and_time/get_current_datetime_tool.cr
@@ -6,6 +6,8 @@ module Tools::DateAndTime
   class GetCurrentDatetimeTool < BuiltInFunction
     name "get_current_datetime"
 
+    side_effects SideEffects::None
+
     description "Returns the current date and time as a string in ISO 8601 format."
 
     runner Runner

--- a/src/tools/toolsets/experimental/patch_text_file_tool.cr
+++ b/src/tools/toolsets/experimental/patch_text_file_tool.cr
@@ -6,6 +6,8 @@ module Tools::Experimental
   class PatchTextFileTool < BuiltInFunction
     name "apply_patch_to_text_file"
 
+    side_effects SideEffects::FileRead | SideEffects::FileWrite | SideEffects::CommandExec
+
     @@patch_version : String? = nil
 
     def self.patch_version

--- a/src/tools/toolsets/experimental/regex_edit_tool.cr
+++ b/src/tools/toolsets/experimental/regex_edit_tool.cr
@@ -7,6 +7,7 @@ module Tools::Experimental
   # in text-based files and replacing them with new text.
   class RegexTextEditTool < BuiltInFunction
     name "str_regex_replace_in_text_file"
+    side_effects SideEffects::FileRead | SideEffects::FileWrite
 
     description "Replaces strings that match a regular expression with a new string in a text file within the current directory."
 

--- a/src/tools/toolsets/file_management/create_directory_tool.cr
+++ b/src/tools/toolsets/file_management/create_directory_tool.cr
@@ -8,6 +8,7 @@ module Tools::FileManagement
   # directory and does not allow creation of paths that escape the root.
   class CreateDirectoryTool < BuiltInFunction
     name "create_directory"
+    side_effects SideEffects::DirRead | SideEffects::DirWrite
 
     description "Creates a new directory at the specified relative path within the current directory."
 

--- a/src/tools/toolsets/file_management/delete_file_tool.cr
+++ b/src/tools/toolsets/file_management/delete_file_tool.cr
@@ -9,6 +9,7 @@ module Tools::FileManagement
   # prepends a timestamp prepended to the filename.
   class DeleteFileTool < BuiltInFunction
     name "delete_file"
+    side_effects SideEffects::FileRead | SideEffects::FileWrite | SideEffects::FileDelete
 
     description "Deletes a file within the current directory by moving it to the `#{FileHelper::DELETED_FILES_PATH}` folder " \
                 "with a ms-resolution timestamp prepended to the filename. This allows for file recovery if deletion " \

--- a/src/tools/toolsets/file_management/find_files_tool.cr
+++ b/src/tools/toolsets/file_management/find_files_tool.cr
@@ -11,15 +11,14 @@ module Tools::FileManagement
     side_effects SideEffects::FileRead | SideEffects::DirRead
 
     # Provide a description for the tool
-    description "Finds files and directories in a directory hierarchy by matching a glob pattern."
+    description "Finds files and directories in a directory hierarchy at `path` by matching a glob pattern in `expression`."
 
     # Define the acceptable parameter using the `param` method
     param "expression", required: true,
       description: "The glob pattern expression with which to find matching files and directories. "
-    param "path", required: false,
-      description: "Optional. The starting point from where this tool looks for " \
-                   "files and directories matching the path pattern. Defaults to \".\" if not" \
-                   "specified or empty string."
+    param "path", required: true,
+      description: "The directory inside which this tool looks for " \
+                   "files and directories matching the `expression` pattern."
     param "max", type: Param::Type::Num, required: false,
       description: "Optional. Maxmimum number of matches to return (default is #{FileHelper::MAX_FIND_FILE_MATCHES})"
     param "sort", type: Param::Type::Bool, required: false,
@@ -33,15 +32,13 @@ module Tools::FileManagement
 
       def execute(args : JSON::Any) : String
         pattern = args["expression"]?.try(&.as_s?) || return error_response("The required glob `expression` was not specified")
-
-        start = args["path"]?.try(&.as_s?) || "."
-        start = "." if start.empty?
+        path = args["path"]?.try(&.as_s?) || return error_response("The required starting directory `path` was not specified")
 
         max = args["max"]?.try(&.as_i?) || MAX_FIND_FILE_MATCHES
         sort = args["sort"]?.try(&.as_bool?)
         sort = true if sort.nil?
 
-        find_pattern = "#{start}/#{pattern}"
+        find_pattern = "#{path}/#{pattern}"
 
         unless within_current_directory?(resolve_path(find_pattern))
           return error_response("Looking outside current directory not allowed.")

--- a/src/tools/toolsets/file_management/find_files_tool.cr
+++ b/src/tools/toolsets/file_management/find_files_tool.cr
@@ -8,6 +8,7 @@ module Tools::FileManagement
   # avoiding access to unauthorized paths.
   class FindFilesTool < BuiltInFunction
     name "find_files"
+    side_effects SideEffects::FileRead | SideEffects::DirRead
 
     # Provide a description for the tool
     description "Finds files and directories in a directory hierarchy by matching a glob pattern."

--- a/src/tools/toolsets/file_management/find_files_tool.cr
+++ b/src/tools/toolsets/file_management/find_files_tool.cr
@@ -32,7 +32,9 @@ module Tools::FileManagement
 
       def execute(args : JSON::Any) : String
         pattern = args["expression"]?.try(&.as_s?) || return error_response("The required glob `expression` was not specified")
-        path = args["path"]?.try(&.as_s?) || return error_response("The required starting directory `path` was not specified")
+        path = args["path"]?.try(&.as_s?).try(&.strip) || return error_response("The required starting directory `path` was not specified")
+
+        return error_response("The required `path` must not be empty") if path.empty?
 
         max = args["max"]?.try(&.as_i?) || MAX_FIND_FILE_MATCHES
         sort = args["sort"]?.try(&.as_bool?)

--- a/src/tools/toolsets/file_management/rename_file_tool.cr
+++ b/src/tools/toolsets/file_management/rename_file_tool.cr
@@ -7,6 +7,7 @@ module Tools::FileManagement
   # It ensures the operation is performed securely within the allowed directory, avoiding access to unauthorized paths.
   class RenameFileTool < BuiltInFunction
     name "rename_or_move_file"
+    side_effects SideEffects::FileRead | SideEffects::FileMove | SideEffects::DirRead | SideEffects::DirMove
 
     description "Rename a file or directory, or move it to another sub-folder, but you may not move it outside this directory." \
                 "like the `mv` command but restricted to the current folder."

--- a/src/tools/toolsets/file_management/search_files_tool.cr
+++ b/src/tools/toolsets/file_management/search_files_tool.cr
@@ -8,6 +8,7 @@ module Tools::FileManagement
   # allowed directory, avoiding access to unauthorized paths.
   class SearchFilesTool < BuiltInFunction
     name "search_files"
+    side_effects SideEffects::FileRead | SideEffects::DirRead
 
     description "Searches files for lines containing a match to the given search pattern and " \
                 "returns matching lines with line numbers."

--- a/src/tools/toolsets/file_management/search_files_tool.cr
+++ b/src/tools/toolsets/file_management/search_files_tool.cr
@@ -17,8 +17,8 @@ module Tools::FileManagement
       description: "A single file path, or a glob pattern expression with which to find matching files."
     param "pattern", type: Param::Type::Str, required: true,
       description: "The text or pattern to search for in each file."
-    param "search_regex", type: Param::Type::Bool, required: false,
-      description: "Optional. Set to true to indicate `search_pattern` is a regular expression (default is false.)"
+    param "pattern_is_regex", type: Param::Type::Bool, required: false,
+      description: "Optional. If true then `pattern` is used as a regular expression. Default is false."
     param "max_files", type: Param::Type::Num,
       description: "Optional. Maxmimum number of files to search within (default is #{FileHelper::MAX_FIND_FILE_MATCHES})"
 

--- a/src/tools/toolsets/image_editing/create_image_file_tool.cr
+++ b/src/tools/toolsets/image_editing/create_image_file_tool.cr
@@ -8,6 +8,7 @@ module Tools::ImageEditing
   # the current directory.
   class CreateImageFileTool < BuiltInFunction
     name "create_image_file"
+    side_effects SideEffects::FileWrite
 
     description "Creates an image file from base64 encoded image data at the specified path. " \
                 "Ensures the file is created within the current directory and does not overwrite existing files."

--- a/src/tools/toolsets/image_editing/read_image_file_tool.cr
+++ b/src/tools/toolsets/image_editing/read_image_file_tool.cr
@@ -7,6 +7,7 @@ module Tools::ImageEditing
   # It ensures the operation is performed securely within the allowed directory, avoiding access to unauthorized paths.
   class ReadImageFileTool < BuiltInFunction
     name "read_image_file"
+    side_effects SideEffects::FileRead
 
     # Provide a description for the tool
     description "Reads the content of a specified image file in the current directory and returns it as a base64 encoded data URL string. " \

--- a/src/tools/toolsets/shell_access/shell_command_tool.cr
+++ b/src/tools/toolsets/shell_access/shell_command_tool.cr
@@ -72,6 +72,9 @@ module Tools::ShellAccess
 
     name "shell_command"
 
+    # Don't know what the chell command does, so assume anything is possible
+    side_effects SideEffects::All
+
     COMMON_DESCRIPTION = "Executes one of the allowed shell commands from within the " \
                          "current project's directory and returns the shell command's output." \
                          "Commands with restricted terms always require approval."

--- a/src/tools/toolsets/text_editing/insert_lines_in_text_file.cr
+++ b/src/tools/toolsets/text_editing/insert_lines_in_text_file.cr
@@ -8,6 +8,7 @@ module Tools::TextEditing
   # allowed directory, avoiding access to unauthorized paths.
   class InsertLinesInTextFileTool < BuiltInFunction
     name "str_insert_in_text_file"
+    side_effects SideEffects::FileRead | SideEffects::FileWrite
 
     description "Insert text at a specific location in a text file within the current directory."
 

--- a/src/tools/toolsets/text_editing/read_text_file_tool.cr
+++ b/src/tools/toolsets/text_editing/read_text_file_tool.cr
@@ -46,8 +46,9 @@ module Tools::TextEditing
         resolved_path = resolve_path(file_path)
 
         return error_response("Access to the specified path '#{file_path}' is not allowed.") unless within_current_directory?(resolved_path)
-        return error_response("The specified file '#{file_path}' does not exist.") unless valid_file?(resolved_path)
-        return error_response("The specified file '#{file_path}' is not a text-based file.") unless text_file?(resolved_path)
+        return error_response("The path '#{file_path}' does not exist.") unless valid_path?(resolved_path)
+        return error_response("The path '#{file_path}' is not a file.") unless valid_file?(resolved_path)
+        return error_response("The file '#{file_path}' is not a text file.") unless text_file?(resolved_path)
 
         begin
           content = read_text_file(resolved_path, line_numbers, line_range)

--- a/src/tools/toolsets/text_editing/read_text_file_tool.cr
+++ b/src/tools/toolsets/text_editing/read_text_file_tool.cr
@@ -31,7 +31,9 @@ module Tools::TextEditing
       include FileHelper
 
       def execute(args : JSON::Any) : String
-        file_path = args["file_path"]?.try(&.as_s?) || return error_response("The required `file_path` was not specified")
+        file_path = args["file_path"]?.try(&.as_s?).try(&.strip) ||
+                    return error_response("The required `file_path` was not specified")
+
         line_numbers = args["include_line_numbers"]?.try &.as_bool? || false
         line_range = if range = args["line_range"]?
                        if (arr = range.as_a?) && arr.size == 2 && (line_start = arr[0]?.try(&.as_i?)) && (line_end = arr[1]?.try(&.as_i?))
@@ -42,6 +44,8 @@ module Tools::TextEditing
                      else
                        [1, -1] # entire file
                      end
+
+        return error_response("The required `file_path` must not be empty") if file_path.empty?
 
         resolved_path = resolve_path(file_path)
 

--- a/src/tools/toolsets/text_editing/read_text_file_tool.cr
+++ b/src/tools/toolsets/text_editing/read_text_file_tool.cr
@@ -8,6 +8,7 @@ module Tools::TextEditing
   # allowed directory, avoiding access to unauthorized paths.
   class ReadTextFileTool < BuiltInFunction
     name "read_text_file"
+    side_effects SideEffects::FileRead
 
     # Provide a description for the tool
     description "Read the contents of a text file within the current directory. " \

--- a/src/tools/toolsets/text_editing/replace_lines_in_text_file.cr
+++ b/src/tools/toolsets/text_editing/replace_lines_in_text_file.cr
@@ -8,6 +8,7 @@ module Tools::TextEditing
   # allowed directory, avoiding access to unauthorized paths.
   class ReplaceLinesInTextFileTool < BuiltInFunction
     name "str_replace_lines_in_text_file"
+    side_effects SideEffects::FileRead | SideEffects::FileWrite
 
     description "Replace a range of lines in a text file within the current directory with given text."
 

--- a/src/tools/toolsets/text_editing/replace_text_file_tool.cr
+++ b/src/tools/toolsets/text_editing/replace_text_file_tool.cr
@@ -8,6 +8,7 @@ module Tools::TextEditing
   # allowed directory, avoiding access to unauthorized paths.
   class ReplaceTextInTextFileTool < BuiltInFunction
     name "str_replace_in_text_file"
+    side_effects SideEffects::FileRead | SideEffects::FileWrite
 
     description "Replaces a specified string in a text file within the current directory with a new string." \
                 "This is used for making precise edits."

--- a/src/tools/toolsets/text_editing/write_text_file_tool.cr
+++ b/src/tools/toolsets/text_editing/write_text_file_tool.cr
@@ -7,6 +7,7 @@ module Tools::TextEditing
   # the current directory.
   class WriteTextFileTool < BuiltInFunction
     name "write_text_file"
+    side_effects SideEffects::FileRead | SideEffects::FileWrite
 
     description "Create a text file within the current directory and write the given content. " \
                 "Create entire path to the file if needed. DOES NOT overwrite existing file unless requested."

--- a/src/tools/toolsets/web/http_get_web_page_as_markdown.cr
+++ b/src/tools/toolsets/web/http_get_web_page_as_markdown.cr
@@ -10,6 +10,7 @@ module Tools::Web
   # The `HttpGetWebAsMarkdownTool` class defines a tool for making HTTP GET requests to retrieve web pages as Markdown.
   class HttpGetWebAsMarkdownTool < BuiltInFunction
     name "http_get_web_page_as_markdown"
+    side_effects SideEffects::NetRead
 
     description <<-DESC
     Makes an HTTP GET request to a given web site URL that returns the content

--- a/src/tools/toolsets/web/http_get_web_page_tool.cr
+++ b/src/tools/toolsets/web/http_get_web_page_tool.cr
@@ -9,6 +9,7 @@ module Tools::Web
   # The `HttpGetWebPageTool` class defines a tool for making HTTP GET requests to retrieve text content.
   class HttpGetWebPageTool < BuiltInFunction
     name "http_get_web_page"
+    side_effects SideEffects::NetRead
 
     description <<-DESC
     Makes an HTTP GET request to a given URL that returns text and returns the content type and content.

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@iconify-json/pixelarticons": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@iconify-json/pixelarticons/-/pixelarticons-1.2.5.tgz",
-      "integrity": "sha512-29Xt2wRDbzRvyBTOEeowbOkjKGdzIa/yTra1sEXgNJLPLytPvbTnr9YZ8CxHAIIbMS0/5vYPsJx6uCmM8ixRkQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@iconify-json/pixelarticons/-/pixelarticons-1.2.6.tgz",
+      "integrity": "sha512-OG1GrDA//OpUfjD8kAxOGhvcTbaYqX+MGjq0KtyRs8yyG++dZ58DOV+VYZBIelwnpRbuh1QtiIa/tfG8M+9wdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -89,15 +89,15 @@
       "license": "MIT"
     },
     "node_modules/@iconify/utils": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.1.tgz",
-      "integrity": "sha512-MwzoDtw9rO1x+qfgLTV/IVXsHDBqeYZoMIQC8SfxfYSlaSUG+oWiAcoiB1yajAda6mqblm4/1/w2E8tRu7a7Tw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@antfu/install-pkg": "^1.1.0",
         "@iconify/types": "^2.0.0",
-        "mlly": "^1.8.2"
+        "import-meta-resolve": "^4.2.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -151,14 +151,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -214,9 +214,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -231,9 +231,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -248,9 +248,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -265,9 +265,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -285,9 +285,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -305,9 +305,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -325,9 +325,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -345,9 +345,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -365,9 +365,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -385,9 +385,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -402,9 +402,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -421,9 +421,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -438,9 +438,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -455,26 +455,36 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@sveltejs/acorn-typescript": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
-      "integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+      "integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
       }
     },
+    "node_modules/@sveltejs/load-config": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.1.1.tgz",
+      "integrity": "sha512-BXXm+VOH/9X4N7Dd1iZ2MqA1h7M+9i2noI8QYuLDY8QcN2WHYn7D/VK/+IJNfcAmRw7ACNJ538UT9GXIhnBTiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
     "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-7.0.0.tgz",
-      "integrity": "sha512-ILXmxC7HAsnkK2eslgPetrqqW1BKSL7LktsFgqzNj83MaivMGZzluWq32m25j2mDOjmSKX7GGWahePhuEs7P/g==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-7.1.2.tgz",
+      "integrity": "sha512-DrUBA2UXRfDmUX/ZTiEopd3X40yavsJF1FX2RygcuIScHL7o5YX1fMvoYnDhjeJQC4weCOklirpNWlcb2NiSeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -492,49 +502,49 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
-      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
+      "integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "^5.19.0",
-        "jiti": "^2.6.1",
+        "enhanced-resolve": "5.21.6",
+        "jiti": "^2.7.0",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.2.4"
+        "tailwindcss": "4.3.1"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
-      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
+      "integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.2.4",
-        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
-        "@tailwindcss/oxide-darwin-x64": "4.2.4",
-        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
-        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
-        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
+        "@tailwindcss/oxide-android-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-x64": "4.3.1",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.1",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.1",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.1",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.1",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.1"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
-      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
+      "integrity": "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==",
       "cpu": [
         "arm64"
       ],
@@ -549,9 +559,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
-      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
+      "integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
       "cpu": [
         "arm64"
       ],
@@ -566,9 +576,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
-      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
+      "integrity": "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==",
       "cpu": [
         "x64"
       ],
@@ -583,9 +593,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
-      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
+      "integrity": "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==",
       "cpu": [
         "x64"
       ],
@@ -600,9 +610,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
-      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
+      "integrity": "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==",
       "cpu": [
         "arm"
       ],
@@ -617,9 +627,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
-      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
+      "integrity": "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==",
       "cpu": [
         "arm64"
       ],
@@ -637,9 +647,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
-      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
+      "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
       "cpu": [
         "arm64"
       ],
@@ -657,9 +667,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
-      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
+      "integrity": "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==",
       "cpu": [
         "x64"
       ],
@@ -677,9 +687,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
-      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
+      "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
       "cpu": [
         "x64"
       ],
@@ -697,9 +707,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
-      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
+      "integrity": "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -715,11 +725,11 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.8.1",
-        "@emnapi/runtime": "^1.8.1",
-        "@emnapi/wasi-threads": "^1.1.0",
-        "@napi-rs/wasm-runtime": "^1.1.1",
-        "@tybys/wasm-util": "^0.10.1",
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -727,9 +737,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
-      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
+      "integrity": "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==",
       "cpu": [
         "arm64"
       ],
@@ -744,9 +754,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
-      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
+      "integrity": "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==",
       "cpu": [
         "x64"
       ],
@@ -761,28 +771,28 @@
       }
     },
     "node_modules/@tailwindcss/typography": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
-      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
+      "integrity": "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-selector-parser": "6.0.10"
       },
       "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+        "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
       }
     },
     "node_modules/@tailwindcss/vite": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.4.tgz",
-      "integrity": "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.1.tgz",
+      "integrity": "sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tailwindcss/node": "4.2.4",
-        "@tailwindcss/oxide": "4.2.4",
-        "tailwindcss": "4.2.4"
+        "@tailwindcss/node": "4.3.1",
+        "@tailwindcss/oxide": "4.3.1",
+        "tailwindcss": "4.3.1"
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
@@ -796,9 +806,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -807,9 +817,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -821,9 +831,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -900,9 +910,9 @@
       }
     },
     "node_modules/daisyui": {
-      "version": "5.5.19",
-      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.5.19.tgz",
-      "integrity": "sha512-pbFAkl1VCEh/MPCeclKL61I/MqRIFFhNU7yiXoDDRapXN4/qNCoMxeCCswyxEEhqL5eiTTfwHvucFtOE71C9sA==",
+      "version": "5.5.23",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.5.23.tgz",
+      "integrity": "sha512-xuheNUSL4T6ZVtWXoioqcNkjoyGX85QTDz4HTw2aBPfqk4fuMjax5HDo8qCmpV6M1YN8bGvfx5BpYCoDeRlt+A==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -930,16 +940,16 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.7.1.tgz",
-      "integrity": "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==",
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
-      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -958,9 +968,9 @@
       "license": "MIT"
     },
     "node_modules/esrap": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.5.tgz",
-      "integrity": "sha512-/yLB1538mag+dn0wsePTe8C0rDIjUOaJpMs2McodSzmM2msWcZsBSdRtg6HOBt0A/r82BN+Md3pgwSc/uWt2Ig==",
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.12.tgz",
+      "integrity": "sha512-On0QbLyaiAkVC4eXtgnXK9Kh2opit+3rcUSOc45DqJ2s/X2eXAHsGOKRSJ6IDagQEW5vPyivANfXUiqgXC67Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1022,6 +1032,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -1033,9 +1054,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1316,9 +1337,9 @@
       }
     },
     "node_modules/local-pkg": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
-      "integrity": "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
+      "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1351,9 +1372,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.2.tgz",
-      "integrity": "sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1406,9 +1427,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "dev": true,
       "funding": [
         {
@@ -1425,15 +1446,18 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/package-manager-detector": {
       "version": "1.6.0",
@@ -1482,9 +1506,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -1502,7 +1526,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1556,14 +1580,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -1572,21 +1596,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/sade": {
@@ -1613,24 +1637,24 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.55.5",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.5.tgz",
-      "integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
+      "version": "5.56.3",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.3.tgz",
+      "integrity": "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@sveltejs/acorn-typescript": "^1.0.10",
         "@types/estree": "^1.0.5",
         "@types/trusted-types": "^2.0.7",
         "acorn": "^8.12.1",
         "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.4",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.4",
+        "esrap": "^2.2.11",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",
@@ -1641,13 +1665,14 @@
       }
     },
     "node_modules/svelte-check": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.6.tgz",
-      "integrity": "sha512-kP1zG81EWaFe9ZyTv4ZXv44Csi6Pkdpb7S3oj6m+K2ec/IcDg/a8LsFsnVLqm2nxtkSwsd5xPj/qFkTBgXHXjg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.6.0.tgz",
+      "integrity": "sha512-KhVnDFDSid57mmZtHz8gfW8AAGylOZ0vPnOIzVmAL+urzwK8sBYXRss953gD8T0OdgAQ11mdWhE6uadmtOz8TQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
+        "@sveltejs/load-config": "0.1.1",
         "chokidar": "^4.0.1",
         "fdir": "^6.2.0",
         "picocolors": "^1.0.0",
@@ -1665,9 +1690,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
-      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
+      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -1686,9 +1711,9 @@
       }
     },
     "node_modules/tinyexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
-      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1696,9 +1721,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1735,9 +1760,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1802,17 +1827,17 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
-        "tinyglobby": "^0.2.16"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -1828,7 +1853,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/webui/src/lib/Session.svelte
+++ b/webui/src/lib/Session.svelte
@@ -133,8 +133,8 @@
     id: string,
     title: string,
     input_args: Common.InputArg[],
-    description?: string | undefined,
-    pre_filled?: Common.InputValues | null,
+    description: string | undefined,
+    pre_filled: Common.InputValues | null,
   ) {
     inputs_dialog_config.id = id;
     inputs_dialog_config.title = title;


### PR DESCRIPTION

### What?

**Early access, experimental**

- Add `google_ai_studio` LLM provider type for Google AI Studio, using the endpoint definition from [Open AI compatibility doc](https://ai.google.dev/gemini-api/docs/openai).
  - Expects API key via `GOOGLE_AI_API_KEY` environment variable.
  - Since current endpoint is in beta and may change over time, the following environment variables can be used to override built-in defaults in the future.
    - `GOOGLE_AI_ENDPOINT` to replace default: `https://generativelanguage.googleapis.com`
    - `GOOGLE_AI_OPENAI_CHAT_PATH` to replace default: `/v1beta/openai/chat/completions`

**New, improvements, and fixes**

- Add session configuration properties to allow / disallow system tools:
  - `allow_tool_discovery:` Can be set to `true` to allow tool discovery / install by AI models; `false` by default.
  - `allow_sub_agents:` Can be set to `true` to disallow spawning sub-agents by AI models; `false` by default.
- Add **enforced system configuration** mode where Enkaidu looks at a platform specific system location for `enkaidu.yml`
  - For Windows, it looks for `C:\Windows\System32\drivers\etc\hosts\enkaidu.yml`
  - Otherwise, it looks for `/etc/enkaidu.yml`
  - If found, it refuses to load any local / profile config files, enforcing system config ONLY
- Add **read-only mode**, configurable as follows, that restricts all built-tools to only those with read-only side-effects
  - Add `readonly: true | false` to `session:` settings on Config.
  - Support `--readonly` flag that puts Enkaidu into readonly mode
- All built-in tools declare their side-effects
  - List of active tools includes side-effects and summary.
- Enable streaming mode by default!
  - **Deprecating** `-S`/`--streaming` flags, they do nothing; will be removed.

Under the hood:
- Define `LLM::Function::SideEffects` flags that every function / tool must declare. This allows Enkaidu to identify and filter by side-effects for read-only mode.

### Why?

**Gemini OpenAI provider type**

- The Google AI Stdui Open AI compatibility endpoint, like Azure's, doesn't easily conform to the pattern offered by `openai` provider. This should make it easy to configure Gemini models.
 
**Allow / disallow system tools**

- With small models and small context windows, these tools can burden the context window, especially since small models are less likely to be able to use these tools well.

**Enforced system config mode**

- For restricted systems / environments, this alows an admin to control the configuration

**Read-only mode**

- Useful to be sure that accidental modification does not happen when using a readonly Enkaidu session

**Streaming by default**

- Streaming was disabled by default only because Enkaidu did not support Markdown output rendering. With Markdown rendering supported for streaming, it makes for a better user experience to enable it by default. (Can still be disabled via config)
