### PR TITLE
Make sub agents work better

### DIFF
--- a/release_notes/v0.9.8-pre.md
+++ b/release_notes/v0.9.8-pre.md
@@ -7,6 +7,7 @@
 
 - Fix the error reported by Azure Open AI models when spawning agents.
 - Fix an internal method mapping connection instance back to the LLM provider label / type
+- Fix a bug where creating new session stacks with tools resulted in function schema corruption.
 
 #### UNDER THE HOOD
 

--- a/release_notes/v0.9.8-pre.md
+++ b/release_notes/v0.9.8-pre.md
@@ -6,6 +6,7 @@
 #### FIXES
 
 - Fix the error reported by Azure Open AI models when spawning agents.
+- Fix an internal method mapping connection instance back to the LLM provider label / type
 
 #### UNDER THE HOOD
 

--- a/release_notes/v0.9.8-pre.md
+++ b/release_notes/v0.9.8-pre.md
@@ -1,0 +1,13 @@
+
+#### IMPROVEMENTS
+
+- Sub-agents (via `spawn_agent` tool) that receive the calling session's context no longer receive the last turn in the context, helping them focus on the prompt given when spawned.
+
+#### FIXES
+
+- Fix the error reported by Azure Open AI models when spawning agents.
+
+#### UNDER THE HOOD
+
+- Added an API option to exclude last turn when forking a session's history. This is needed for spawning agents via tool calling, where excluding the last turn removes the prompt that caused to tool calling in the first place, in turn avoiding inconsistency in the session history BUT more importantly preventing the sub-agent from trying to do the same thing that led to it being spawned.
+

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: enkaidu
-version: 0.9.7
+version: 0.9.8-pre
 license: MPL-2.0
 description: Command line tool that can use local and remote AI models to assist
   with local editing and refinement tasks.

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: enkaidu
-version: 0.9.8-pre
+version: 0.9.8
 license: MPL-2.0
 description: Command line tool that can use local and remote AI models to assist
   with local editing and refinement tasks.

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -99,7 +99,10 @@ module Enkaidu
     end
 
     # Create a new session "forked" from a given `Session` to create a duplicate session.
-    def initialize(fork_from : Session, keep_tools = true, keep_prompts = true, keep_history = true, system_prompt_name = nil)
+    def initialize(fork_from : Session,
+                   keep_tools = true, keep_prompts = true, keep_history = true,
+                   system_prompt_name = nil,
+                   exclude_last_turn = false)
       @recorder = fork_from.recorder
       @opts = fork_from.opts
       @renderer = fork_from.renderer
@@ -111,7 +114,7 @@ module Enkaidu
                             end
       @chat = setup_chat(override_system_prompt: override_sys_prompt,
         override_model_name: fork_from.chat.model)
-      chat.fork(fork_from.chat) if keep_history
+      chat.fork(fork_from.chat, exclude_last_turn) if keep_history
 
       if keep_tools
         @mcp_functions = fork_from.mcp_functions.dup

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -89,13 +89,7 @@ module Enkaidu
     end
 
     private def connection_provider_type
-      case @connection
-      when LLM::Ollama::Connection      then "ollama"
-      when LLM::AzureOpenAI::Connection then "azure_openai"
-      else
-        # Default because above subclass from the OpenAI one
-        "openai"
-      end
+      LLM.connection_provider_label(@connection)
     end
 
     # Create a new session "forked" from a given `Session` to create a duplicate session.

--- a/src/enkaidu/session_manager.cr
+++ b/src/enkaidu/session_manager.cr
@@ -52,10 +52,11 @@ module Enkaidu
     # Push a session in current stack, make a query, and then extract the session outline
     # before popping the session. Return the extracted session as a JSON string,
     # or `nil` on error.
-    def ask_forked_session(query : String, keep_history = false) : String?
+    def ask_forked_session(query : String, keep_history = false, exclude_last_turn = false) : String?
       stack = current
       stack.push_session(keep_history: keep_history,
-        keep_tools: true, keep_prompts: true)
+        keep_tools: true, keep_prompts: true,
+        exclude_last_turn: exclude_last_turn)
       session = stack.session
       session.renderer.session_pushed(depth: stack.depth, keep_history: keep_history,
         keep_tools: true, keep_prompts: true)

--- a/src/enkaidu/session_stack.cr
+++ b/src/enkaidu/session_stack.cr
@@ -28,12 +28,13 @@ module Enkaidu
     end
 
     def push_session(keep_tools = true, keep_prompts = true, keep_history = true,
-                     system_prompt_name : String? = nil) : Nil
+                     system_prompt_name : String? = nil, exclude_last_turn = false) : Nil
       @session_stack.push Session.new(fork_from: session,
         keep_tools: keep_tools,
         keep_prompts: keep_prompts,
         keep_history: keep_history,
-        system_prompt_name: system_prompt_name)
+        system_prompt_name: system_prompt_name,
+        exclude_last_turn: exclude_last_turn)
     end
 
     def pop_session(retain : Retain, replace : Bool = false, &)

--- a/src/enkaidu/tools/sub_agent_function.cr
+++ b/src/enkaidu/tools/sub_agent_function.cr
@@ -10,7 +10,8 @@ module Enkaidu
     side_effects SideEffects::None
 
     description <<-DESC
-    Run a prompt in a completely fresh, isolated context window and receive the result as `[query, response]`.
+    Submit a prompt to the LLM to process in a separate context window, and receive the result as `[query, response]`.
+    Call the tool with a clean context (default), or include current session context so the sub-agent can use that information to process the prompt.
 
     **Use this tool whenever the task:**
     - would consume significant tokens (large codebases, long or many documents, multi-step research)
@@ -19,11 +20,10 @@ module Enkaidu
     DESC
 
     param "prompt", type: Param::Type::Str, required: true,
-      description: "The full instruction for the sub-agent; be explicit, especially when not including history."
-    param "include_caller_history", type: Param::Type::Bool, required: false,
+      description: "The full instruction for the sub-agent."
+    param "include_session_context", type: Param::Type::Bool, required: false,
       description: <<-PDESC
-      Set to true only when the task requires awareness of the current session, e.g. summarizing the conversation,
-      continuing a thread, or referencing prior decisions.
+      Set to true only when the sub-agent can benefit from awareness of the current session.
       PDESC
 
     runner Runner
@@ -40,18 +40,15 @@ module Enkaidu
 
         return error_response("Required `prompt` was empty") if prompt.empty?
 
-        wrapped_prompt = <<-WRAPPER
-        <important>
-        * You are a spawned agent of Enkaidu.
-        * DO NOT spawn another agent UNLESS you're trying to split a task into multiple steps.
-        * REMEMBER to install tools you need; _not all tools are pre-installed_.
-        </important>
+        # Fork the session to process the prompt.
+        # Since this is a tool call, exclude the last turn if keeping history
+        # to (a) avoid an incomplete request in history, and (b) to avoid repeating the same
+        # prompt that initiated this tool call.
+        reply = func.runtime.session_manager.ask_forked_session(prompt,
+          keep_history,
+          exclude_last_turn: true)
 
-        #{prompt}
-
-        WRAPPER
-        func.runtime.session_manager.ask_forked_session(wrapped_prompt, keep_history) ||
-          error_response("Nil response")
+        reply || error_response("Nil response")
       rescue ex
         error_response(ex.message)
       end

--- a/src/llm.cr
+++ b/src/llm.cr
@@ -5,6 +5,8 @@ require "./llm/google_ai_studio"
 require "./llm/ollama"
 
 module LLM
+  class Error < Exception; end
+
   # Development use; set to `true` to trace HTTP
   TRACE = false
 
@@ -27,6 +29,18 @@ module LLM
     when "ollama"           then Ollama::Connection.new
     when "azure_openai"     then AzureOpenAI::Connection.new
     when "google_ai_studio" then GoogleAIStudio::Connection.new
+    end
+  end
+
+  # Returns the provider label for the given connection instance
+  def self.connection_provider_label(connection : Connection) : String
+    case connection
+    when LLM::Ollama::Connection      then "ollama"
+    when LLM::AzureOpenAI::Connection then "azure_openai"
+    when GoogleAIStudio::Connection   then "google_ai_studio"
+    when LLM::OpenAI::Connection      then "openai"
+    else
+      raise Error.new("Unknown connection implementation: #{connection.class}")
     end
   end
 end

--- a/src/llm/local_function.cr
+++ b/src/llm/local_function.cr
@@ -36,7 +36,7 @@ module LLM
     end
 
     # one list per class; do not edit
-    @@params = [] of Param
+    @@params = {} of String => Param
     @@input_schema = nil
 
     def initialize(origin = "LEGACY / Built-in", settings = nil)
@@ -45,7 +45,7 @@ module LLM
 
     # Iterate through each parameter
     private def each_param(& : Param ->)
-      @@params.each do |param|
+      @@params.each do |_, param|
         yield param
       end
     end
@@ -123,7 +123,7 @@ module LLM
 
     # Define a parameter for this LLM Function.
     macro param(name, description, type = Param::Type::Str, required = false)
-      @@params << Param.new({{name}}, {{type}}, {{description}}, {{required}})
+      @@params[{{name}}] ||= Param.new({{name}}, {{type}}, {{description}}, {{required}})
     end
 
     # Define the method that is used to create the Runner

--- a/src/llm/openai/chat.cr
+++ b/src/llm/openai/chat.cr
@@ -81,8 +81,9 @@ module LLM::OpenAI
 
     # Replace current session with a "fork" of the session from the given
     # `Chat` instance; may fail if `self` is not compatible.
-    def fork(from : Chat) : Nil
-      @history.branch(from.@history)
+    # Optionally, exclude the last "turn" (last user prompt and subsequent responses).
+    def fork(from : Chat, exclude_last_turn = false) : Nil
+      @history.branch(from.@history, exclude_last_turn)
       @usage = @history.last_usage
     end
 

--- a/src/llm/openai/chat/history.cr
+++ b/src/llm/openai/chat/history.cr
@@ -33,9 +33,23 @@ module LLM::OpenAI
       @messages = [] of MessageWrap
     end
 
-    def branch(from : History)
+    #
+    # Copy the messages from another session's history, optionally excluding the last "turn".
+    def branch(from : History, exclude_last_turn = false)
       @messages = from.@messages.dup
-      # Remember the pointer f
+      if exclude_last_turn
+        # Find the most recent "user" message and drop all messages associated with that
+        # prompt: i.e. delete it and subsequent messages.
+        ex_user_index = @messages.rindex do |msg|
+          msg.message.is_a? Message::MultiContent
+        end
+        unless ex_user_index.nil?
+          # Position of last user message is the count of messages we
+          # want to retain
+          @messages = @messages[0, ex_user_index]
+        end
+      end
+      # Remember where we branched so we can detect what is new to this session history
       @branch_index = @messages.size
     end
 

--- a/src/llm/openai/chat/message/multi_content.cr
+++ b/src/llm/openai/chat/message/multi_content.cr
@@ -3,6 +3,8 @@ require "../message"
 module LLM::OpenAI
   # Represents a multi-content message in a request to the LLM
   class Message::MultiContent < Message
+    ROLE = "user"
+
     property content = [] of Content
 
     def initialize(prompt : String, attach : ChatInclusions? = nil)

--- a/src/llm/openai/chat/message/response.cr
+++ b/src/llm/openai/chat/message/response.cr
@@ -4,6 +4,8 @@ require "../usage"
 module LLM::OpenAI
   # Represents a response message from the LLM
   class Message::Response < Message
+    ROLE = "assistant"
+
     property content : String?
 
     @[JSON::Field(ignore_serialize: ((reasoning = @reasoning).nil? || reasoning.empty?))]

--- a/src/llm/openai/chat/message/tool_call.cr
+++ b/src/llm/openai/chat/message/tool_call.cr
@@ -3,6 +3,8 @@ require "../message"
 module LLM::OpenAI
   # Represents a tool-call result message in a request to the LLM
   class Message::ToolCall < Message
+    ROLE = "tool"
+
     property tool_call_id : String
     property name : String
     property content : String


### PR DESCRIPTION
### What?

-  Sub-agents (via `spawn_agent` tool) that receive the calling session's context no longer receive the last turn in the context, helping them focus on the prompt given when spawned.
- Fix the error reported by Azure Open AI models when spawning agents. Closes #169 
- Fix an internal method mapping connection instance back to the LLM provider label / type
- Fix a bug where creating new session stacks with tools resulted in function schema corruption.

### Why?

Excluding the last turn when branching a session for a sub-agent removes the prompt that triggered the agent, and removes an incomplete turn where the request and too calls are present but the tool replies are not when the agent sends its prompt.