### PR TITLE
Global in-memory state and conditional continuation commands

### DIFF
--- a/release_notes/v0.9.10-pre.md
+++ b/release_notes/v0.9.10-pre.md
@@ -1,0 +1,12 @@
+#### NEW
+
+
+#### IMPROVEMENTS
+
+- Reading audio returns base64-encoded attachments but the model only sees the text; tweaked the tool description to avoid confusing the model.
+
+#### FIXES
+
+- Fix handling of tools returning audio attachments. (Doh.)
+
+#### UNDER THE HOOD

--- a/release_notes/v0.9.10-pre.md
+++ b/release_notes/v0.9.10-pre.md
@@ -4,6 +4,8 @@
 #### IMPROVEMENTS
 
 - Reading audio returns base64-encoded attachments but the model only sees the text; tweaked the tool description to avoid confusing the model.
+- Add `max` to list of `/think` effort levels.
+- Support `/help [/command]` to get help for a slash command. E.g. `/help /think`
 
 #### FIXES
 

--- a/release_notes/v0.9.10-pre.md
+++ b/release_notes/v0.9.10-pre.md
@@ -1,5 +1,13 @@
 #### NEW
 
+- Support conditional continuation commands that can be used to test pre-defined conditions and affect whether to continue or break out of the current macro
+  - Conditional commands start with a `?`
+  - Following are currently available:
+    - `?break_if file_exists:PATH`
+    - `?break_if file:PATH contains:STR`
+    - `?break_unless file_exists:PATH`
+    - `?break_unless file:PATH contains:STR`
+  - While they can be entered as a query prompt, they are only useful within macros.
 
 #### IMPROVEMENTS
 

--- a/release_notes/v0.9.10-pre.md
+++ b/release_notes/v0.9.10-pre.md
@@ -3,11 +3,23 @@
 - Support conditional continuation commands that can be used to test pre-defined conditions and affect whether to continue or break out of the current macro
   - Conditional commands start with a `?`
   - Currently, `?break` conditional command available with following sub-commands:
-    - `?break if file_exists:PATH`
-    - `?break if file:PATH contains:STR`
-    - `?break unless file_exists:PATH`
-    - `?break unless file:PATH contains:STR`
+    - `?break if file_exists=PATH`
+    - `?break if file=PATH contains=STR`
+    - `?break if global ns=NAMESPACE key=STR equals=STR`
+    - `?break unless file_exists=PATH`
+    - `?break unless file=PATH contains=STR`
+    - `?break unless global ns=NAMESPACE key=STR equals=STR`
   - While they can be entered as a query prompt, they are only useful within macros.
+- Support in-memory global state that can be used to store key/value pairs under different namespaces, providing a way to communicate between agents, turns, and sessions.
+  - Added `/state` command with `global` (or `g`) sub-command with
+    - `/state g namespaces` to list namespaces in use
+    - `/state g set ns=NAME key=KEY value=STR` to add / update a key in a namespace
+    - `/state g get ns=NAME key=KEY` to get the value for a key in a namespace
+  - Added a session configuration property `allow_global_state` which is `false` by default
+  - Added two tools for set/get key/values from the global state _iff_ the session's `allow_global_state` property is set to `true`:
+    - `get_global_state` tool
+    - `set_global_state` tool
+  - Macros can ask models to use these tools to update state, and then use `?break ... global ...` conditional continuations to react to state changes.
 
 #### IMPROVEMENTS
 

--- a/release_notes/v0.9.10-pre.md
+++ b/release_notes/v0.9.10-pre.md
@@ -2,11 +2,11 @@
 
 - Support conditional continuation commands that can be used to test pre-defined conditions and affect whether to continue or break out of the current macro
   - Conditional commands start with a `?`
-  - Following are currently available:
-    - `?break_if file_exists:PATH`
-    - `?break_if file:PATH contains:STR`
-    - `?break_unless file_exists:PATH`
-    - `?break_unless file:PATH contains:STR`
+  - Currently, `?break` conditional command available with following sub-commands:
+    - `?break if file_exists:PATH`
+    - `?break if file:PATH contains:STR`
+    - `?break unless file_exists:PATH`
+    - `?break unless file:PATH contains:STR`
   - While they can be entered as a query prompt, they are only useful within macros.
 
 #### IMPROVEMENTS

--- a/release_notes/v0.9.10-pre.md
+++ b/release_notes/v0.9.10-pre.md
@@ -10,5 +10,6 @@
 #### FIXES
 
 - Fix handling of tools returning audio attachments. (Doh.)
+- Recorder flushes IO after every write to ensure crashes don't lose recording entries
 
 #### UNDER THE HOOD

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: enkaidu
-version: 0.9.9
+version: 0.9.10-pre
 license: MPL-2.0
 description: Command line tool that can use local and remote AI models to assist
   with local editing and refinement tasks.

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: enkaidu
-version: 0.9.10-pre
+version: 0.9.10
 license: MPL-2.0
 description: Command line tool that can use local and remote AI models to assist
   with local editing and refinement tasks.

--- a/src/enkaidu/cli/query_reader.cr
+++ b/src/enkaidu/cli/query_reader.cr
@@ -47,6 +47,8 @@ module Enkaidu::CLI
     def documentation(entry : String)
       if entry.starts_with?('/')
         cached_doc(entry, runtime.commander.help_for(entry))
+      elsif entry.starts_with?('?')
+        cached_doc(entry, runtime.help_for_conditional(entry))
       elsif entry.starts_with?('!')
         cached_doc(entry, runtime.session.macro_description(entry))
       elsif entry.starts_with?("./")
@@ -78,7 +80,9 @@ module Enkaidu::CLI
         # Tab completion for commands and macros
         {
           "Commands and Macros",
-          [runtime.commander.command_names, runtime.session.macro_names].flatten,
+          [runtime.commander.command_names,
+           runtime.session.macro_names,
+           runtime.conditional_command_names].flatten,
         }
       else
         # Nothing to complete
@@ -92,8 +96,8 @@ module Enkaidu::CLI
       text = expression.gsub(/\.(\/[^\s]+)+\/?/) do |match|
         styler.fmt(:query_syntax_path, match)
       end
-      # Slash commands and macros at the start of a prompt
-      text = text.gsub(/^\s*[\/!][a-z_][a-z0-9_\.]+/) do |match|
+      # Slash commands, conditional commands and macros at the start of a prompt
+      text = text.gsub(/^\s*[\/!\?][a-z_][a-z0-9_\.]+/) do |match|
         styler.fmt(
           match.starts_with?('!') ? :query_syntax_macro : :query_syntax_command,
           match)

--- a/src/enkaidu/config.cr
+++ b/src/enkaidu/config.cr
@@ -96,6 +96,7 @@ module Enkaidu
       # Disallowed by default, set to `true` to disallow
       getter? allow_tool_discovery = false
       getter? allow_sub_agents = false
+      getter? allow_global_state = false
 
       getter provider_type : String?
       getter model : String?

--- a/src/enkaidu/recorder.cr
+++ b/src/enkaidu/recorder.cr
@@ -1,9 +1,7 @@
 module Enkaidu
   # Recorder class handles recording in-app events and debug events for troubleshooting LLM comms
   class Recorder
-    FLUSH_AFTER = 10
     private getter rec_io : IO?
-    private getter count_since_flush = 0
 
     # Initializes a new Recorder instance with an optional IO object for recording.
     def initialize(@rec_io = nil); end
@@ -20,9 +18,6 @@ module Enkaidu
       return unless io = rec_io
 
       yield io
-      @count_since_flush += 1
-      return unless count_since_flush >= FLUSH_AFTER
-
       flush
     end
 
@@ -30,7 +25,6 @@ module Enkaidu
     def flush
       return unless io = rec_io
       io.flush
-      @count_since_flush = 0
     end
 
     # Closes the rec_io.

--- a/src/enkaidu/runtime.cr
+++ b/src/enkaidu/runtime.cr
@@ -48,6 +48,10 @@ module Enkaidu
         if session_config.allow_sub_agents?
           session_manager.inject_function SubAgentPromptFunction.new(self)
         end
+        if session_config.allow_global_state?
+          session_manager.inject_function GlobalStateGetFunction.new(self)
+          session_manager.inject_function GlobalStateSetFunction.new(self)
+        end
       end
 
       # HACK ALERT
@@ -65,7 +69,7 @@ module Enkaidu
 
     # Handling code for `?...` commands
     private macro _execute_conditional_command_
-      result = conditional_helper.handle_conditional_command(q)
+      result = conditional_helper.handle_conditional_command(session_manager, q)
       case result[:continue]
       when .break?
         query_queue = [] of String # Empty the current queue

--- a/src/enkaidu/runtime.cr
+++ b/src/enkaidu/runtime.cr
@@ -1,4 +1,5 @@
 require "./slash_commander"
+require "./runtime/*"
 
 module Enkaidu
   class Error < Exception; end
@@ -15,6 +16,8 @@ module Enkaidu
     getter commander : Slash::Commander
     getter renderer : SessionRenderer
     getter options : SessionOptions
+
+    private getter conditional_helper = ConditionalCommandHelper.new
 
     def session
       session_manager.current.session
@@ -41,31 +44,94 @@ module Enkaidu
       session_manager.deploy_injected_functions(session)
     end
 
+    alias QueryQueue = Array(String)
+    alias QueryQueueStack = Array(QueryQueue)
+
+    #
+    # Macros used by the execution loop
+    #
+
+    # Handling code for `?...` commands
+    private macro _execute_conditional_command_
+      result = conditional_helper.handle_conditional_command(q)
+      case result[:continue]
+      when .break?
+        query_queue = [] of String # Empty the current queue
+        if msg = result[:message]
+          renderer.respond_with(msg)
+        end
+      when .abort?
+        query_queue = [] of String
+        query_queue_stack = [] of Array(String)
+        renderer.error_with(result[:message] || "ERROR: Aborting: Unknown reason.")
+      end # else `Yes` so continue
+    end
+
+    # Handling code for `!...` commands
+    private macro _execute_macro_command_
+      if mac_queries = session.find_and_prepare_macro(q)
+        # Push the current query queue on to the stack of queues
+        # iff it's not already empty
+        query_queue_stack << query_queue unless query_queue.empty?
+        # make the macro's queries the current queue
+        query_queue = mac_queries
+        in_macro = true
+        yield Event::Macro
+      else
+        renderer.error_with("ERROR: Aborting: Unknown macro: #{q}")
+        break
+      end
+    end
+
+    # Handling code for `/...` commands
+    private macro _execute_slash_command_
+      if commander.make_it_so(q) == :done
+        yield Event::Done
+      end
+      yield Event::SlashCommand
+    end
+
     def execute_query(query : String, &)
+      # Maintain a stack of query queues; when marcos are invoked,
+      # push current query queue onto stack and use the macro's queries as
+      # current quuery queue.
+      # Why? In effect the current query queue is the "frame" for the currently running macro.
+      # This should allow us to support, for e.g., a `?break_if CONDITION`
+      # command that aborts current macro and continue with the one that
+      # called it.
+      query_queue_stack = QueryQueueStack.new
+      # Current command or commands (if macro invoked)
       query_queue = [query]
+      # Track when macro is invoked
       in_macro = false
+
       while q = query_queue.shift?
         renderer.user_query_text(q, via_query_queue: true) if in_macro
 
         case q = q.strip
+        when .starts_with?("?")
+          _execute_conditional_command_
         when .starts_with?("!")
-          if mac_queries = session.find_and_prepare_macro(q)
-            # Expand the macro at the top of the queue, where
-            # next query awaits; essentially inserting the macro
-            query_queue.insert_all(0, mac_queries)
-          end
-          in_macro = true
-          yield Event::Macro
+          _execute_macro_command_
         when .starts_with?("/")
-          if commander.make_it_so(q) == :done
-            yield Event::Done
-          end
-          yield Event::SlashCommand
+          _execute_slash_command_
         else
           session.ask(query: q,
             attach: commander.take_inclusions!,
             response_json_schema: commander.take_response_schema!)
           yield Event::Prompt
+        end
+        # Check if query queue is empty, and pop from the query queue stack
+        # to continue with next query in outer frame
+        if query_queue.empty?
+          # It's possible prior queues in stack are empty, so we need to unwind until
+          # - either nothing is left
+          # - or we get to a queue with items
+          while !query_queue_stack.empty?
+            # Replace current query queue with one we pushed last onto stack of queues
+            query_queue = query_queue_stack.pop
+            break unless query_queue.empty?
+          end
         end
       end
     rescue ex

--- a/src/enkaidu/runtime.cr
+++ b/src/enkaidu/runtime.cr
@@ -19,6 +19,18 @@ module Enkaidu
 
     private getter conditional_helper = ConditionalCommandHelper.new
 
+    def help_for_conditional(slash_command) : String?
+      if slash_command == conditional_helper.name
+        conditional_helper.help
+      end
+    end
+
+    @conditional_command_names : Array(String)?
+
+    def conditional_command_names : Array(String)
+      @conditional_command_names ||= [conditional_helper.name]
+    end
+
     def session
       session_manager.current.session
     end

--- a/src/enkaidu/runtime/conditional_command_helper.cr
+++ b/src/enkaidu/runtime/conditional_command_helper.cr
@@ -51,6 +51,12 @@ module Enkaidu
       Abort
     end
 
+    # Define the subordinating conjunctions supported by `?break`.
+    enum SubConjunction
+      If
+      Unless
+    end
+
     # Conditional command handling returns a continuation response
     # with a `Continue` value and an optional message.
     alias Continuation = NamedTuple(continue: Continue, message: String?)
@@ -68,124 +74,96 @@ module Enkaidu
       resolved
     end
 
-    # Return a continuation after checking if  given file exists.
-    private def break_if_file_exists(file : String) : Continuation
+    # Return a continuation after checking if/unless  given file exists.
+    private def break_x_file_exists(subcon : SubConjunction, file : String) : Continuation
       case result = resolve_and_validate(file)
       when Continuation then result
       else
         resolved_file = result
         continue = Continue::Yes
         message = nil.as(String?)
-        if file_exists?(resolved_file)
-          continue = Continue::Break
-          message = "INFO: Break: File exists: #{file}"
+        file_exists = file_exists?(resolved_file)
+        case subcon
+        when .if?
+          if file_exists
+            continue = Continue::Break
+            message = "INFO: Break: File exists: #{file}"
+          end
+        when .unless?
+          unless file_exists
+            continue = Continue::Break
+            message = "INFO: Break: File does not exist: #{file}"
+          end
         end
         {continue: continue, message: message}
       end
     end
 
-    # Return a continuation after checking if given file does not exists.
-    private def break_unless_file_exists(file : String) : Continuation
+    # Return a continuation if/unless given `file` exists AND `contains` the given string.
+    private def break_x_file_contains(subcon : SubConjunction, file : String, contains : String) : Continuation
       case result = resolve_and_validate(file)
       when Continuation then result
       else
         resolved_file = result
         continue = Continue::Yes
         message = nil.as(String?)
-        unless File.exists?(resolved_file)
-          continue = Continue::Break
-          message = "INFO: Break: File does not exist: #{file}"
+        file_contains = file_exists?(resolved_file) && File.read(resolved_file).includes?(contains)
+        case subcon
+        when .if?
+          if file_contains
+            continue = Continue::Break
+            message = "INFO: Break: File contains \"#{contains}\""
+          end
+        when .unless?
+          unless file_contains
+            continue = Continue::Break
+            message = "INFO: Break: File doesn't exist, or doesn't contain \"#{contains}\""
+          end
         end
         {continue: continue, message: message}
       end
     end
 
-    # Return a continuation if given `file` exists AND `contains` the given string.
-    private def break_if_file_contains(file : String, contains : String) : Continuation
-      case result = resolve_and_validate(file)
-      when Continuation then result
-      else
-        resolved_file = result
-        continue = Continue::Yes
-        if File.exists?(resolved_file) && File.read(resolved_file).includes?(contains)
-          continue = Continue::Break
-          message = "INFO: Break: File contains \"#{contains}\""
-        end
-        {continue: continue, message: message}
-      end
-    end
-
-    # Return a continuation unless given `file` exists AND `contains` the given string.
-    private def break_unless_file_contains(file : String, contains : String) : Continuation
-      case result = resolve_and_validate(file)
-      when Continuation then result
-      else
-        resolved_file = result
-        continue = Continue::Break
-        if File.exists?(resolved_file) && File.read(resolved_file).includes?(contains)
-          continue = Continue::Yes
-        else
-          message = "INFO: Break: File doesn't exist, or doesn't contain \"#{contains}\""
-        end
-        {continue: continue, message: message}
-      end
-    end
-
-    # Return a continuation if given `key` in `namespace` of global state has a matching `value`.
-    private def break_if_global_state_equals(global_state : KeyValueStore::InMemory,
-                                             ns : String,
-                                             key : String,
-                                             equals : String) : Continuation
+    # Return a continuation if/unless given `key` in `namespace` of global state has a matching `value`.
+    private def break_x_global_state_equals(subcon : SubConjunction, global_state : KeyValueStore::InMemory,
+                                            ns : String, key : String,
+                                            equals : String) : Continuation
       continue = Continue::Yes
       message = nil
-      if (value = global_state.get?(ns, key)) && value == equals
-        continue = Continue::Break
-        message = "INFO: Break: Global state key's value equals: #{equals}"
+      key_value_matched = (value = global_state.get?(ns, key)) && value == equals
+      case subcon
+      when .if?
+        if key_value_matched
+          continue = Continue::Break
+          message = "INFO: Break: Global state key's value equals: #{equals}"
+        end
+      when .unless?
+        unless key_value_matched
+          continue = Continue::Break
+          message = "INFO: Break: Global state key doesn't exist/equal: #{equals}"
+        end
       end
       {continue: continue, message: message}
     end
 
-    # Return a continuation unless given `key` in `namespace` of global state has a matching `value`.
-    private def break_unless_global_state_equals(global_state : KeyValueStore::InMemory,
-                                                 ns : String,
-                                                 key : String,
-                                                 equals : String) : Continuation
-      continue = Continue::Break
-      message = nil
-      if (value = global_state.get?(ns, key)) && value == equals
-        continue = Continue::Yes
-      else
-        message = "INFO: Break: Global state key doesn't exist, or value doesn't equal: #{equals}"
-      end
-      {continue: continue, message: message}
-    end
+    private SUBCONS = SubConjunction.names.map(&.downcase)
 
     # Return true to continue with next query, or
     # false to abort current query queue
     def handle_conditional_command(session_manager : SessionManager, q : String) : Continuation
       case cmd = CommandParser.new(q)
-      when .expect?("?break", "if", file_exists: String)
-        break_if_file_exists(
+      when .expect?(NAME, SUBCONS, file_exists: String)
+        subcon = SubConjunction.parse(cmd.arg_at(1).as(String))
+        break_x_file_exists(subcon,
           file: cmd.arg_named("file_exists").as(String))
-      when .expect?("?break", "if", file: String, contains: String)
-        break_if_file_contains(
+      when .expect?(NAME, SUBCONS, file: String, contains: String)
+        subcon = SubConjunction.parse(cmd.arg_at(1).as(String))
+        break_x_file_contains(subcon,
           file: cmd.arg_named("file").as(String),
           contains: cmd.arg_named("contains").as(String))
-      when .expect?("?break", "if", "global", ns: String, key: String, equals: String)
-        break_if_global_state_equals(
-          session_manager.global_state,
-          ns: cmd.arg_named("ns").as(String),
-          key: cmd.arg_named("key").as(String),
-          equals: cmd.arg_named("equals").as(String))
-      when .expect?("?break", "unless", file_exists: String)
-        break_unless_file_exists(
-          file: cmd.arg_named("file_exists").as(String))
-      when .expect?("?break", "unless", file: String, contains: String)
-        break_unless_file_contains(
-          file: cmd.arg_named("file").as(String),
-          contains: cmd.arg_named("contains").as(String))
-      when .expect?("?break", "unless", "global", ns: String, key: String, equals: String)
-        break_unless_global_state_equals(
+      when .expect?(NAME, SUBCONS, "global", ns: String, key: String, equals: String)
+        subcon = SubConjunction.parse(cmd.arg_at(1).as(String))
+        break_x_global_state_equals(subcon,
           session_manager.global_state,
           ns: cmd.arg_named("ns").as(String),
           key: cmd.arg_named("key").as(String),

--- a/src/enkaidu/runtime/conditional_command_helper.cr
+++ b/src/enkaidu/runtime/conditional_command_helper.cr
@@ -1,0 +1,126 @@
+require "../../sucre/command_parser"
+require "../../tools"
+
+module Enkaidu
+  class ConditionalCommandHelper
+    include Tools::FileHelper
+
+    # Defines the next step following a conditional command
+    enum Continue
+      # Yes means continue with next command in queue
+      Yes
+      # Break means discard current "frame" queue, and continue with next "frame" in the stack
+      # Effectively terminates current macro
+      Break
+      # Abort means discard current frame queue and all queues in the stack, returning user to
+      # the prompt. Reserved for errors
+      Abort
+    end
+
+    # Conditional command handling returns a continuation response
+    # with a `Continue` value and an optional message.
+    alias Continuation = NamedTuple(continue: Continue, message: String?)
+
+    # Return a Tuple with
+    # - continuation with Abort and message if error, OR
+    # - resolved file path
+    private def resolve_and_validate(file : String) : Continuation | String
+      resolved = resolve_path(file)
+
+      unless within_current_directory?(resolved)
+        return {continue: Continue::Abort, message: "ERROR: File is outside current folder, not allowed."}
+      end
+
+      resolved
+    end
+
+    # Return a continuation after checking if  given file exists.
+    private def break_if_file_exists(file : String) : Continuation
+      case result = resolve_and_validate(file)
+      when Continuation then result
+      else
+        resolved_file = result
+        continue = Continue::Yes
+        message = nil.as(String?)
+        if file_exists?(resolved_file)
+          continue = Continue::Break
+          message = "INFO: Break: File exists: #{file}"
+        end
+        {continue: continue, message: message}
+      end
+    end
+
+    # Return a continuation after checking if given file does not exists.
+    private def break_unless_file_exists(file : String) : Continuation
+      case result = resolve_and_validate(file)
+      when Continuation then result
+      else
+        resolved_file = result
+        continue = Continue::Yes
+        message = nil.as(String?)
+        unless File.exists?(resolved_file)
+          continue = Continue::Break
+          message = "INFO: Break: File does not exist: #{file}"
+        end
+        {continue: continue, message: message}
+      end
+    end
+
+    # Return a continuation if given `file` exists AND `contains` the given string.
+    private def break_if_file_contains(file : String, contains : String) : Continuation
+      case result = resolve_and_validate(file)
+      when Continuation then result
+      else
+        resolved_file = result
+        continue = Continue::Yes
+        if File.exists?(resolved_file) && File.read(resolved_file).includes?(contains)
+          continue = Continue::Break
+          message = "INFO: Break: File contains \"#{contains}\""
+        end
+        {continue: continue, message: message}
+      end
+    end
+
+    # Return a continuation if given `file` exists AND `contains` the given string.
+    private def break_unless_file_contains(file : String, contains : String) : Continuation
+      case result = resolve_and_validate(file)
+      when Continuation then result
+      else
+        resolved_file = result
+        continue = Continue::Break
+        if File.exists?(resolved_file) && File.read(resolved_file).includes?(contains)
+          continue = Continue::Yes
+        else
+          message = "INFO: Break: File doesn't exist, or doesn't contain \"#{contains}\""
+        end
+        {continue: continue, message: message}
+      end
+    end
+
+    # Return true to continue with next query, or
+    # false to abort current query queue
+    def handle_conditional_command(q : String) : Continuation
+      case cmd = CommandParser.new(q)
+      when .expect?("?break_if", file_exists: String)
+        break_if_file_exists(
+          file: cmd.arg_named("file_exists").as(String))
+      when .expect?("?break_if", file: String, contains: String)
+        break_if_file_contains(
+          file: cmd.arg_named("file").as(String),
+          contains: cmd.arg_named("contains").as(String))
+      when .expect?("?break_unless", file_exists: String)
+        break_unless_file_exists(
+          file: cmd.arg_named("file_exists").as(String))
+      when .expect?("?break_unless", file: String, contains: String)
+        break_unless_file_contains(
+          file: cmd.arg_named("file").as(String),
+          contains: cmd.arg_named("contains").as(String))
+      else
+        {
+          continue: Continue::Abort,
+          message:  "ERROR: Aborting! Unknown conditional command: #{q}",
+        }
+      end
+    end
+  end
+end

--- a/src/enkaidu/runtime/conditional_command_helper.cr
+++ b/src/enkaidu/runtime/conditional_command_helper.cr
@@ -5,6 +5,35 @@ module Enkaidu
   class ConditionalCommandHelper
     include Tools::FileHelper
 
+    NAME = "?break"
+
+    HELP_BRIEF = "`#{NAME} <sub-command> ...` - Conditionally exit from current macro"
+    HELP       = <<-HELP1
+    #{HELP_BRIEF}
+    - `if file_exists=<PATH>`
+      - Exit macro if given file exists
+    - `if file=<PATH> contains=<STR>`
+      - Exit macro if given file exists and contains given string
+    - `unless file_exists=<PATH>`
+      - Exit macro unless given file exists
+    - `unless file=<PATH> contains=<STR>`
+      - Exit macro unless given file exists and contains given string
+    HELP1
+
+    # Detailed help, in Markdown
+    def help : String
+      HELP
+    end
+
+    # One line help, in Markdown
+    def brief : String
+      HELP_BRIEF
+    end
+
+    def name : String
+      NAME
+    end
+
     # Defines the next step following a conditional command
     enum Continue
       # Yes means continue with next command in queue
@@ -101,17 +130,17 @@ module Enkaidu
     # false to abort current query queue
     def handle_conditional_command(q : String) : Continuation
       case cmd = CommandParser.new(q)
-      when .expect?("?break_if", file_exists: String)
+      when .expect?("?break", "if", file_exists: String)
         break_if_file_exists(
           file: cmd.arg_named("file_exists").as(String))
-      when .expect?("?break_if", file: String, contains: String)
+      when .expect?("?break", "if", file: String, contains: String)
         break_if_file_contains(
           file: cmd.arg_named("file").as(String),
           contains: cmd.arg_named("contains").as(String))
-      when .expect?("?break_unless", file_exists: String)
+      when .expect?("?break", "unless", file_exists: String)
         break_unless_file_exists(
           file: cmd.arg_named("file_exists").as(String))
-      when .expect?("?break_unless", file: String, contains: String)
+      when .expect?("?break", "unless", file: String, contains: String)
         break_unless_file_contains(
           file: cmd.arg_named("file").as(String),
           contains: cmd.arg_named("contains").as(String))

--- a/src/enkaidu/runtime/conditional_command_helper.cr
+++ b/src/enkaidu/runtime/conditional_command_helper.cr
@@ -1,4 +1,5 @@
 require "../../sucre/command_parser"
+require "../../sucre/key_value_store"
 require "../../tools"
 
 module Enkaidu
@@ -14,10 +15,14 @@ module Enkaidu
       - Exit macro if given file exists
     - `if file=<PATH> contains=<STR>`
       - Exit macro if given file exists and contains given string
+    - `if global ns=<NAMESPACE> key=<STR> equals=<STR>`
+      - Exit macro if global state key has matching value
     - `unless file_exists=<PATH>`
       - Exit macro unless given file exists
     - `unless file=<PATH> contains=<STR>`
       - Exit macro unless given file exists and contains given string
+    - `unless global ns=<NAMESPACE> key=<STR> equals=<STR>`
+      - Exit macro unless global state key has matching value
     HELP1
 
     # Detailed help, in Markdown
@@ -110,7 +115,7 @@ module Enkaidu
       end
     end
 
-    # Return a continuation if given `file` exists AND `contains` the given string.
+    # Return a continuation unless given `file` exists AND `contains` the given string.
     private def break_unless_file_contains(file : String, contains : String) : Continuation
       case result = resolve_and_validate(file)
       when Continuation then result
@@ -126,9 +131,38 @@ module Enkaidu
       end
     end
 
+    # Return a continuation if given `key` in `namespace` of global state has a matching `value`.
+    private def break_if_global_state_equals(global_state : KeyValueStore::InMemory,
+                                             ns : String,
+                                             key : String,
+                                             equals : String) : Continuation
+      continue = Continue::Yes
+      message = nil
+      if (value = global_state.get?(ns, key)) && value == equals
+        continue = Continue::Break
+        message = "INFO: Break: Global state key's value equals: #{equals}"
+      end
+      {continue: continue, message: message}
+    end
+
+    # Return a continuation unless given `key` in `namespace` of global state has a matching `value`.
+    private def break_unless_global_state_equals(global_state : KeyValueStore::InMemory,
+                                                 ns : String,
+                                                 key : String,
+                                                 equals : String) : Continuation
+      continue = Continue::Break
+      message = nil
+      if (value = global_state.get?(ns, key)) && value == equals
+        continue = Continue::Yes
+      else
+        message = "INFO: Break: Global state key doesn't exist, or value doesn't equal: #{equals}"
+      end
+      {continue: continue, message: message}
+    end
+
     # Return true to continue with next query, or
     # false to abort current query queue
-    def handle_conditional_command(q : String) : Continuation
+    def handle_conditional_command(session_manager : SessionManager, q : String) : Continuation
       case cmd = CommandParser.new(q)
       when .expect?("?break", "if", file_exists: String)
         break_if_file_exists(
@@ -137,6 +171,12 @@ module Enkaidu
         break_if_file_contains(
           file: cmd.arg_named("file").as(String),
           contains: cmd.arg_named("contains").as(String))
+      when .expect?("?break", "if", "global", ns: String, key: String, equals: String)
+        break_if_global_state_equals(
+          session_manager.global_state,
+          ns: cmd.arg_named("ns").as(String),
+          key: cmd.arg_named("key").as(String),
+          equals: cmd.arg_named("equals").as(String))
       when .expect?("?break", "unless", file_exists: String)
         break_unless_file_exists(
           file: cmd.arg_named("file_exists").as(String))
@@ -144,6 +184,12 @@ module Enkaidu
         break_unless_file_contains(
           file: cmd.arg_named("file").as(String),
           contains: cmd.arg_named("contains").as(String))
+      when .expect?("?break", "unless", "global", ns: String, key: String, equals: String)
+        break_unless_global_state_equals(
+          session_manager.global_state,
+          ns: cmd.arg_named("ns").as(String),
+          key: cmd.arg_named("key").as(String),
+          equals: cmd.arg_named("equals").as(String))
       else
         {
           continue: Continue::Abort,

--- a/src/enkaidu/session.cr
+++ b/src/enkaidu/session.cr
@@ -165,6 +165,11 @@ module Enkaidu
       opts.config.session.try(&.allow_sub_agents?) || false
     end
 
+    # Return based on session override
+    def allow_global_state? : Bool
+      opts.config.session.try(&.allow_global_state?) || false
+    end
+
     # Load the selected LLM's environment variable values into
     # `ENV`; call this method before initializing an LLM connection
     private def setup_envs_from_config
@@ -182,6 +187,29 @@ module Enkaidu
     </empowered>
     EMPOWERED
 
+    private SYSPROMPT_SUB_AGENT = <<-AGENTIC
+    <agentic>
+    * Spawn sub-agents to handle tasks that would otherwise fill your context window, keeping your current session lean and focused.
+      * When to spawn:
+        - The task is self-contained and can produce a concise final answer
+        - The task involves extensive file reading, analysis, or operations that would generate large intermediate outputs
+        - The task is well-scoped and can be completed independently
+      * When to keep work local:
+        - The task is simple or straightforward
+        - The task is tightly coupled to your current work
+        - The task would be difficult to delegate effectively
+    </agentic>
+    AGENTIC
+
+    private SYSPROMPT_GLOBAL_STATE = <<-STATEFUL
+    <stateful>
+    * Set and get global state using key/value pairs that can be grouped under namespaces using the `set_global_state` and `get_global_state` tools.
+    * Use the global state for
+      - tracking progress with iterative tasks, or
+      - communicating between agents, turns, and/or sessions
+    </stateful>
+    STATEFUL
+
     private def system_prompt(override_system_prompt : String?)
       <<-WRAPPED
       You are Enkaidu, a capable assistant with tool calling and the ability to handle complex requests with planning and consideration.
@@ -195,11 +223,15 @@ module Enkaidu
       * Resolve each question before asking follow-ups.
       * Proceed with the plan unless the plan is complicated and warrants user feedback.
       </planner>
-      #{if allow_tool_discovery?
-          SYSPROMPT_TOOL_DISCOVERY
-        end}#{if prompt = override_system_prompt
-                "\n<additional-guidance>\n#{prompt.strip}\n</additional-guidance>"
-              end}
+      #{if allow_sub_agents?
+          SYSPROMPT_SUB_AGENT
+        end}#{if allow_global_state?
+                SYSPROMPT_GLOBAL_STATE
+              end}#{if allow_tool_discovery?
+                      SYSPROMPT_TOOL_DISCOVERY
+                    end}#{if prompt = override_system_prompt
+                            "\n<additional-guidance>\n#{prompt.strip}\n</additional-guidance>"
+                          end}
       WRAPPED
     end
 

--- a/src/enkaidu/session_manager.cr
+++ b/src/enkaidu/session_manager.cr
@@ -1,5 +1,7 @@
 require "./session_stack"
 
+require "../sucre/key_value_store"
+
 module Enkaidu
   # Manager a stack of sessions
   class SessionManager
@@ -7,11 +9,15 @@ module Enkaidu
 
     getter current : SessionStack
 
+    # Maintain a global key/value state in memory
+    getter global_state : KeyValueStore::InMemory
+
     # The app / runtime can inject tools that are available to all sessions
     protected getter injected_tools = [] of LLM::LocalFunction
 
     def initialize(session : Session)
       @current = SessionStack.new("prime", session)
+      @global_state = KeyValueStore::InMemory.new
       @stacks[current.name] = current
     end
 

--- a/src/enkaidu/slash/state.cr
+++ b/src/enkaidu/slash/state.cr
@@ -1,0 +1,68 @@
+require "./command"
+
+module Enkaidu::Slash
+  class StateCommand < Command
+    NAME = "/state"
+
+    HELP_BRIEF = "`#{NAME} <sub-command>` - State management"
+
+    HELP = <<-HELP1
+    #{HELP_BRIEF}
+    - `global (or g) namespaces (or ns)`
+      - List namespaces in the global state
+    - `global (or g) set ns=NAMESPACE key=KEY value=STR`
+      - Set a global state key/value within the given namespace
+    - `global (or g) get ns=NAMESPACE key=KEY`
+      - Get a global state value for a key within the given namespace
+    HELP1
+
+    def name : String
+      NAME
+    end
+
+    def brief : String
+      HELP_BRIEF
+    end
+
+    def help : String
+      HELP
+    end
+
+    private def list_namespaces(session, namespaces)
+      text = String.build do |io|
+        if namespaces.empty?
+          io.puts "- (None so far)"
+        else
+          namespaces.each do |name|
+            io << "- `" << name << "`\n"
+          end
+        end
+        io << '\n'
+      end
+      session.renderer.respond_with("List of global state namespaces:", text, markdown: true)
+    end
+
+    def handle(session_manager : SessionManager, cmd : CommandParser)
+      session = session_manager.current.session
+
+      if cmd.expect?(NAME, ["global", "g"], ["namespaces", "ns"])
+        list_namespaces(session, session_manager.global_state.namespaces)
+      elsif cmd.expect?(NAME, ["global", "g"], "set", ns: String, key: String, value: String)
+        ns = cmd.arg_named("ns").as(String)
+        key = cmd.arg_named("key").as(String)
+        value = cmd.arg_named("value").as(String)
+        session_manager.global_state.set(ns, key, value)
+        session.renderer.respond_with("Updated. Namespace revision: #{session_manager.global_state.revision(ns)}")
+      elsif cmd.expect?(NAME, ["global", "g"], "get", ns: String, key: String)
+        ns = cmd.arg_named("ns").as(String)
+        key = cmd.arg_named("key").as(String)
+        value = session_manager.global_state.get?(ns, key) || "<unknown>"
+        session.renderer.respond_with("#{key} = #{value}")
+      else
+        session.renderer.warning_with(
+          "ERROR: Unknown or incomplete sub-command: #{cmd.arg_at? 0}",
+          help: HELP, markdown: true)
+      end
+    end
+  end
+end

--- a/src/enkaidu/slash/think.cr
+++ b/src/enkaidu/slash/think.cr
@@ -4,15 +4,17 @@ module Enkaidu::Slash
   class ThinkCommand < Command
     NAME = "/think"
 
-    THINK_EFFORT = ["none", "low", "medium", "high", "default"]
+    THINK_EFFORT = LLM::Reasoning.names.map(&.downcase)
+    THINK_LEVELS = (LLM::Reasoning.values.reject { |eff| eff.default? || eff.none? }).map(&.to_s.downcase)
 
     HELP_BRIEF = "`#{NAME} [#{THINK_EFFORT.join(" or ")}]` - Request thinking effort, or show current effort"
     HELP       = <<-HELP1
     #{HELP_BRIEF}
-    - If `none`, disables thinking / reasoning if the model supports it
-    - If `low` or `medium` or `high`, enables thinking / reasoning, though granularity depends on the model
-    - If `default`, uses the default model reasoning behaviour
-    - Else shows the requested thinking effort
+    - Without parameters, `/think` shows the currently configured (or default) thinking effort
+    - With an effort parameter
+      - `none` disables thinking / reasoning if the model supports it
+      - `default` resets to use the model's default thinking level
+      - #{(THINK_LEVELS.map { |eff| "`#{eff}`" }).join(", ")} enable thinking / reasoning as supported by model
     HELP1
 
     def name : String

--- a/src/enkaidu/slash_commander.cr
+++ b/src/enkaidu/slash_commander.cr
@@ -47,7 +47,8 @@ module Enkaidu::Slash
     C_BYE  = "/bye"
     C_HELP = "/help"
 
-    H_C_BYE = "`#{C_BYE}` - Exit Enkaidu"
+    H_C_BYE  = "`#{C_BYE}` - Exit Enkaidu"
+    H_C_HELP = "`#{C_HELP} [/command]` - Help for all commands in brief, or for a command in detail"
 
     def help_for(slash_command) : String?
       if command = commands[slash_command]? || commands["/#{slash_command}"]?
@@ -65,6 +66,8 @@ module Enkaidu::Slash
       @help ||= String.build do |sio|
         sio.print "- "
         sio.puts H_C_BYE
+        sio.print "- "
+        sio.puts H_C_HELP
         commands.each_value do |command|
           sio.print "- "
           sio.puts command.brief
@@ -83,8 +86,11 @@ module Enkaidu::Slash
       when C_BYE
         state = :done
       when C_HELP
-        renderer.respond_with "The following `/` (slash) commands available:",
-          help: help, markdown: true
+        if (cmd_name = cmd.arg_at?(1)) && (command = commands[cmd_name]?)
+          renderer.respond_with "", help: command.help, markdown: true
+        else
+          renderer.respond_with "", help: help, markdown: true
+        end
       else
         if command = commands[cmd_name]?
           command.handle(session_manager, cmd)

--- a/src/enkaidu/slash_commander.cr
+++ b/src/enkaidu/slash_commander.cr
@@ -31,6 +31,7 @@ module Enkaidu::Slash
         MacroCommand.new,
         PromptCommand.new(self),
         SessionCommand.new,
+        StateCommand.new,
         SystemPromptCommand.new,
         ThinkCommand.new,
         ToolCommand.new,

--- a/src/enkaidu/tools/global_state_get_function.cr
+++ b/src/enkaidu/tools/global_state_get_function.cr
@@ -1,0 +1,65 @@
+require "../../llm"
+require "./session_built_in_function"
+
+module Enkaidu
+  # Defines a tool / function to make a single query to Enkaidu
+  class GlobalStateGetFunction < SessionBuiltInFunction
+    name "get_global_state"
+
+    # By itself, has no sideffects
+    side_effects SideEffects::None
+
+    description <<-DESC
+    Get the values for one or more keys within a namespace in the global state available across sessions and turns.
+    A monotonically increasing revision counter per namespace is updated for every change to a key in that namespace.
+    DESC
+
+    param "namespace", type: Param::Type::Str, required: true,
+      description: "A namespace is a container of key/value pairs"
+    param "keys", type: Param::Type::Arr, required: true,
+      description: "An array of one or more keys for which to retrieve the values. Unknown keys will return a `null` value."
+
+    runner Runner
+
+    # This defines the runner that is instantiated to
+    # execute the function.
+    class Runner < SessionBuiltInFunction::Runner
+      # Implement this method to handle the LLM function call, and return a
+      # String with the JSON value.
+      def execute(args : JSON::Any) : String
+        namespace = args["namespace"]?.try(&.as_s?) || return error_response("Required `namespace` was not specified")
+        json_keys = args["keys"]?.try(&.as_a?) || return error_response("Required `keys` was not specified")
+
+        keys = convert_json_array(json_keys)
+
+        global_state = func.runtime.session_manager.global_state
+        key_values = {} of String => String?
+        keys.each do |key|
+          key_values[key] = global_state.get?(namespace, key)
+        end
+        success_response(namespace, global_state.revision(namespace), key_values)
+      rescue ex
+        error_response(ex.message)
+      end
+
+      # Create a success response as a JSON string
+      private def success_response(namespace, revision, key_values)
+        {
+          namespace => {
+            "revision" => revision,
+          },
+          "key_values" => key_values,
+        }.to_json
+      end
+
+      private def convert_json_array(json_array : Array(JSON::Any)) : Array(String)
+        json_array.map do |json_any|
+          unless str = json_any.as_s?
+            raise ArgumentError.new("Expected keys to be strings, not: #{json_any}")
+          end
+          str
+        end
+      end
+    end
+  end
+end

--- a/src/enkaidu/tools/global_state_set_function.cr
+++ b/src/enkaidu/tools/global_state_set_function.cr
@@ -1,0 +1,71 @@
+require "../../llm"
+require "./session_built_in_function"
+
+module Enkaidu
+  # Defines a tool / function to make a single query to Enkaidu
+  class GlobalStateSetFunction < SessionBuiltInFunction
+    name "set_global_state"
+
+    # By itself, has no sideffects
+    side_effects SideEffects::None
+
+    description <<-DESC
+    Set (or update) the value for one or more keys within a namespace in the global state available across sessions and turns.
+    A monotonically increasing revision counter per namespace is updated for every change to a key in that namespace.
+    DESC
+
+    param "namespace", type: Param::Type::Str, required: true,
+      description: "A namespace is a container of key/value pairs"
+    param "keys", type: Param::Type::Arr, required: true,
+      description: "An array of one or more keys with corresponding value entries in the `values` parameter"
+    param "values", type: Param::Type::Arr, required: true,
+      description: "An array of one or more values corresponding to entries in 'keys' parameter "
+
+    runner Runner
+
+    # This defines the runner that is instantiated to
+    # execute the function.
+    class Runner < SessionBuiltInFunction::Runner
+      # Implement this method to handle the LLM function call, and return a
+      # String with the JSON value.
+      def execute(args : JSON::Any) : String
+        namespace = args["namespace"]?.try(&.as_s?) || return error_response("Required `namespace` was not specified")
+        json_keys = args["keys"]?.try(&.as_a?) || return error_response("Required `keys` was not specified")
+        json_values = args["values"]?.try(&.as_a?) || return error_response("Required `values` was not specified")
+
+        keys = convert_json_array(json_keys)
+        values = convert_json_array(json_values)
+
+        return error_response("Number of keys and values must be the same.") if keys.size != values.size
+
+        global_state = func.runtime.session_manager.global_state
+        keys.each_with_index do |key, i|
+          value = values[i]
+          global_state.set(namespace, key, value)
+        end
+        success_response(namespace, global_state.revision(namespace), keys.size)
+      rescue ex
+        error_response(ex.message)
+      end
+
+      # Create a success response as a JSON string
+      private def success_response(namespace, revision, count)
+        {
+          namespace => {
+            "revision" => revision,
+          },
+          "keys_updated" => count,
+        }.to_json
+      end
+
+      private def convert_json_array(json_array : Array(JSON::Any)) : Array(String)
+        json_array.map do |json_any|
+          unless str = json_any.as_s?
+            raise ArgumentError.new("Expected keys to be strings, not: #{json_any}")
+          end
+          str
+        end
+      end
+    end
+  end
+end

--- a/src/llm/chat.cr
+++ b/src/llm/chat.cr
@@ -18,6 +18,7 @@ module LLM
     Low
     Medium
     High
+    Max
     Default
   end
 

--- a/src/llm/openai/chat.cr
+++ b/src/llm/openai/chat.cr
@@ -129,6 +129,7 @@ module LLM::OpenAI
           when Function::Reply::Text  then attachments.text(att.data)
           when Function::Reply::File  then attachments.file_data(att.base64_data, att.file_name)
           when Function::Reply::Image then attachments.image_url(att.image_url.to_s)
+          when Function::Reply::Audio then attachments.input_audio(att.base64_data, att.format)
           end
         end
       end

--- a/src/sucre/key_value_store/in_memory_key_value_store.cr
+++ b/src/sucre/key_value_store/in_memory_key_value_store.cr
@@ -1,0 +1,56 @@
+require "json"
+
+module KeyValueStore
+  alias Key = String
+  alias Value = String
+  alias Revision = Int64
+  alias Namespace = String
+
+  class NamedState
+    getter name : Namespace
+    getter revision : Revision
+
+    @store : Hash(Key, Value)
+
+    def initialize(@name)
+      @store = {} of Key => Value
+      @revision = 0
+    end
+
+    def set(key : Key, value : Value) : Void
+      @store[key] = value
+      @revision += 1
+    end
+
+    def get?(key : Key) : Value?
+      @store[key]?
+    end
+  end
+
+  # In-memory key/value store allows setting/getting key/value pairs grouped
+  # by a namespace, with revision tracking in each namespace.
+  class InMemory
+    private getter state_hash = {} of String => NamedState
+
+    def set(name : Namespace, key : Key, value : Value) : Void
+      named_state = if state_hash.has_key?(name)
+                      state_hash[name]
+                    else
+                      state_hash[name] = NamedState.new(name)
+                    end
+      named_state.set(key, value)
+    end
+
+    def get?(name : Namespace, key : Key) : Value?
+      state_hash[name]?.try(&.get?(key))
+    end
+
+    def revision(name : Namespace) : Revision
+      state_hash[name]?.try(&.revision) || 0_i64
+    end
+
+    def namespaces
+      state_hash.keys
+    end
+  end
+end

--- a/src/sucre/key_value_store/key_value_store.cr
+++ b/src/sucre/key_value_store/key_value_store.cr
@@ -1,0 +1,4 @@
+require "./in_memory_key_value_store"
+
+module KeyValueStores
+end

--- a/src/tools/toolsets/audio_editing/read_audio_file_tool.cr
+++ b/src/tools/toolsets/audio_editing/read_audio_file_tool.cr
@@ -10,7 +10,7 @@ module Tools::AudioEditing
     side_effects SideEffects::FileRead
 
     # Provide a description for the tool
-    description "Reads the content of a specified audio file in the current directory and returns it as base64 encoded text. " \
+    description "Reads the content of a specified audio file in the current directory and returns it as _input audio_ attachment. " \
                 "Supports the following audio formats: #{AudioHelper::ALLOWED_AUDIO_FORMATS.join(',')}. "
 
     # Define the acceptable parameter using the `param` method

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -38,21 +38,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -151,14 +151,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
-      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.2"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.133.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
-      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "version": "0.137.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
+      "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
-      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.3.tgz",
+      "integrity": "sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==",
       "cpu": [
         "arm64"
       ],
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
-      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.3.tgz",
+      "integrity": "sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==",
       "cpu": [
         "arm64"
       ],
@@ -214,9 +214,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
-      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.3.tgz",
+      "integrity": "sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==",
       "cpu": [
         "x64"
       ],
@@ -231,9 +231,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
-      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.3.tgz",
+      "integrity": "sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==",
       "cpu": [
         "x64"
       ],
@@ -248,9 +248,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
-      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.3.tgz",
+      "integrity": "sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==",
       "cpu": [
         "arm"
       ],
@@ -265,9 +265,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
-      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.3.tgz",
+      "integrity": "sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==",
       "cpu": [
         "arm64"
       ],
@@ -285,9 +285,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
-      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.3.tgz",
+      "integrity": "sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==",
       "cpu": [
         "arm64"
       ],
@@ -305,9 +305,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
-      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.3.tgz",
+      "integrity": "sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==",
       "cpu": [
         "ppc64"
       ],
@@ -325,9 +325,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
-      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.3.tgz",
+      "integrity": "sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==",
       "cpu": [
         "s390x"
       ],
@@ -345,9 +345,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
-      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.3.tgz",
+      "integrity": "sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==",
       "cpu": [
         "x64"
       ],
@@ -365,9 +365,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
-      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.3.tgz",
+      "integrity": "sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==",
       "cpu": [
         "x64"
       ],
@@ -385,9 +385,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
-      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.3.tgz",
+      "integrity": "sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==",
       "cpu": [
         "arm64"
       ],
@@ -402,9 +402,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
-      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.3.tgz",
+      "integrity": "sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==",
       "cpu": [
         "wasm32"
       ],
@@ -412,18 +412,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
-      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
+      "integrity": "sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==",
       "cpu": [
         "arm64"
       ],
@@ -438,9 +438,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
-      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.3.tgz",
+      "integrity": "sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==",
       "cpu": [
         "x64"
       ],
@@ -472,9 +472,9 @@
       }
     },
     "node_modules/@sveltejs/load-config": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.1.1.tgz",
-      "integrity": "sha512-BXXm+VOH/9X4N7Dd1iZ2MqA1h7M+9i2noI8QYuLDY8QcN2WHYn7D/VK/+IJNfcAmRw7ACNJ538UT9GXIhnBTiA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.0.tgz",
+      "integrity": "sha512-1LgZ/qUqSoq+QorD83lk2hka79Px0wXNW2q5V1nZlxGhQgw1jrsIbVz5YiCeucVLo4XvFLjXukUaQjIiqowkcg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -806,9 +806,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -910,9 +910,9 @@
       }
     },
     "node_modules/daisyui": {
-      "version": "5.5.23",
-      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.5.23.tgz",
-      "integrity": "sha512-xuheNUSL4T6ZVtWXoioqcNkjoyGX85QTDz4HTw2aBPfqk4fuMjax5HDo8qCmpV6M1YN8bGvfx5BpYCoDeRlt+A==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.6.3.tgz",
+      "integrity": "sha512-QvdtXnQ/tD5a18Y/+NJkJ1+ggwRtMF84GHTHCCAto5SNqYwZj8SUQQviKMpe1cKR7vMo/evTBDExkYd19KloBQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -968,9 +968,9 @@
       "license": "MIT"
     },
     "node_modules/esrap": {
-      "version": "2.2.12",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.12.tgz",
-      "integrity": "sha512-On0QbLyaiAkVC4eXtgnXK9Kh2opit+3rcUSOc45DqJ2s/X2eXAHsGOKRSJ6IDagQEW5vPyivANfXUiqgXC67Rw==",
+      "version": "2.2.13",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.13.tgz",
+      "integrity": "sha512-m8jH5hZgJE2RRUK/jjkGPcJEDAV+dYnZYFkosQaPTcE+Yw4xynXHOo6FUdwaWBtdR3b1MMa7wEDTSHeR2VWsGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -986,9 +986,9 @@
       }
     },
     "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1506,9 +1506,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "dev": true,
       "funding": [
         {
@@ -1580,13 +1580,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
-      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
+      "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.133.0",
+        "@oxc-project/types": "=0.137.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -1596,21 +1596,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.3",
-        "@rolldown/binding-darwin-arm64": "1.0.3",
-        "@rolldown/binding-darwin-x64": "1.0.3",
-        "@rolldown/binding-freebsd-x64": "1.0.3",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
-        "@rolldown/binding-linux-arm64-musl": "1.0.3",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-gnu": "1.0.3",
-        "@rolldown/binding-linux-x64-musl": "1.0.3",
-        "@rolldown/binding-openharmony-arm64": "1.0.3",
-        "@rolldown/binding-wasm32-wasi": "1.0.3",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
-        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+        "@rolldown/binding-android-arm64": "1.1.3",
+        "@rolldown/binding-darwin-arm64": "1.1.3",
+        "@rolldown/binding-darwin-x64": "1.1.3",
+        "@rolldown/binding-freebsd-x64": "1.1.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.3",
+        "@rolldown/binding-linux-arm64-musl": "1.1.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-gnu": "1.1.3",
+        "@rolldown/binding-linux-x64-musl": "1.1.3",
+        "@rolldown/binding-openharmony-arm64": "1.1.3",
+        "@rolldown/binding-wasm32-wasi": "1.1.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.3",
+        "@rolldown/binding-win32-x64-msvc": "1.1.3"
       }
     },
     "node_modules/sade": {
@@ -1637,9 +1637,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.56.3",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.3.tgz",
-      "integrity": "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==",
+      "version": "5.56.4",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.4.tgz",
+      "integrity": "sha512-/d0QHehmRuJW8gVz395MTkPcPozxzdjBMBE8oEYGz8O3b9KTMzzQ9ZHJQLuFKOHOPQbU6kx/X4iid/EBBzH7iw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1654,7 +1654,7 @@
         "clsx": "^2.1.1",
         "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.11",
+        "esrap": "^2.2.12",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",
@@ -1665,14 +1665,14 @@
       }
     },
     "node_modules/svelte-check": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.6.0.tgz",
-      "integrity": "sha512-KhVnDFDSid57mmZtHz8gfW8AAGylOZ0vPnOIzVmAL+urzwK8sBYXRss953gD8T0OdgAQ11mdWhE6uadmtOz8TQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.1.tgz",
+      "integrity": "sha512-FGUOmAqxXdN/H9Zm8slrqO7SLtFisXRB7rfOsHNJ3MLTD2po/+Stg8XyErkpumPHbuUiYTcqrEIzxpVWKTLqtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
-        "@sveltejs/load-config": "0.1.1",
+        "@sveltejs/load-config": "^0.2.0",
         "chokidar": "^4.0.1",
         "fdir": "^6.2.0",
         "picocolors": "^1.0.0",
@@ -1827,16 +1827,16 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.16",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
-      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
+      "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.15",
-        "rolldown": "1.0.3",
+        "rolldown": "~1.1.2",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -1853,7 +1853,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.18",
+        "@vitejs/devtools": "^0.3.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",


### PR DESCRIPTION
### What?

**New**

- Support **conditional continuation** commands that can be used to test pre-defined conditions and affect whether to continue or break out of the current macro
  - Conditional commands start with a `?`
  - Currently, `?break` conditional command available with following sub-commands:
    - `?break if file_exists=PATH`
    - `?break if file=PATH contains=STR`
    - `?break if global ns=NAMESPACE key=STR equals=STR`
    - `?break unless file_exists=PATH`
    - `?break unless file=PATH contains=STR`
    - `?break unless global ns=NAMESPACE key=STR equals=STR`
  - While they can be entered as a query prompt, they are only useful within macros.
- Support in-memory **global state** that can be used to store key/value pairs under different namespaces, providing a way to communicate between agents, turns, and sessions.
  - Added `/state` command with `global` (or `g`) sub-command with
    - `/state g namespaces` to list namespaces in use
    - `/state g set ns=NAME key=KEY value=STR` to add / update a key in a namespace
    - `/state g get ns=NAME key=KEY` to get the value for a key in a namespace
  - Added a session configuration property `allow_global_state` which is `false` by default
  - Added two tools for set/get key/values from the global state _iff_ the session's `allow_global_state` property is set to `true`:
    - `get_global_state` tool
    - `set_global_state` tool
  - Macros can ask models to use these tools to update state, and then use `?break ... global ...` conditional continuations to react to state changes.

**Improvements**

- Reading audio returns base64-encoded attachments but the model only sees the text; tweaked the tool description to avoid confusing the model.
- Add `max` to list of `/think` effort levels.
- Support `/help [/command]` to get help for a slash command. E.g. `/help /think`

**Under the hood**

- Update web UI `node` dependencies

### Why?

**Conditional continuation**

Macros can call macros, but we had no way for a macro to ask a model to do some work and then test for that. Using `?break` with `if...` or `unless...` conditions, macros can now iterate by calling themselves or other macros and exit by testing for a file change. (Over time other tests can be added.)

**Global state**

While using the file system for state is OK, something that provides a more targeted way to manage state via tools and commands will perform better. This also will be usable in readonly mode.
